### PR TITLE
Automatically build and push docker image on every commit to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: build
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,44 @@
+name: deploy
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_REPOSITORY: ghcr.io/${{ github.repository }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+
+    - name: Build image
+      run: make docker-build
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Tag image for github container repository with commit SHA
+      run: 'docker tag controller:latest $GITHUB_REPOSITORY:${{env.GITHUB_SHA}}'
+
+    - name: Push image for github container repository with commit SHA
+      run: 'docker push controller:latest $GITHUB_REPOSITORY:${{env.GITHUB_SHA}}'
+
+    - name: Tag image for github container repository with latest
+      run: 'docker tag controller:latest $GITHUB_REPOSITORY:latest'
+
+    - name: Push image for github container repository with latest
+      run: 'docker push controller:latest $GITHUB_REPOSITORY:latest'


### PR DESCRIPTION
*Description of changes:*

This change will introduce a new "deploy" github action to build and push a docker image on every new commit to `main` to [Github packages](https://github.com/features/packages) Since we already are on Github, this simplifies publishing the docker image by avoiding having to setup separate a separate container repository elsewhere.

Destination of the container image will be `ghcr.io/aws/aws-cloud-map-mcs-controller-for-k8s`

The image will be tagged with the `git commit SHA` as well as `latest` We can also revisit this in the future if needed.

In the future, we can add support to publish to other destinations like AWS ECR, DockerHub, etc.

Since the docker build will need to build the project in order to push a docker image, I am changing the build action to only run on PRs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
