### PR TITLE
Fix make docker-build command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,14 @@
 # Build the manager binary
-FROM golang:1.15 as builder
+FROM golang:1.17 as builder
 
 WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
+
+# Copy the Go Modules manifests, plus the source
+COPY . ./
+
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
-
-# Copy the go source
-COPY main.go main.go
-COPY pkg/api api/
-COPY pkg/controllers controllers/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go


### PR DESCRIPTION
*Description of changes:*

`make docker-build` command is now working. Basically, the code needed to be under the `pkg` folder in order to build, when it wasn't before. To avoid having to explicitly copy directory or file that needs to be built, I'm just copying everything into the docker context.

Tested by running `make docker-build` locally and confirming that it works!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
