### PR TITLE
Fix deploy action by correctly referencing env var

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,10 +32,10 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Tag image for github container repository with commit SHA
-      run: 'docker tag controller:latest $GITHUB_REPOSITORY:${{env.GITHUB_SHA}}'
+      run: 'docker tag controller:latest $GITHUB_REPOSITORY:$GITHUB_SHA'
 
     - name: Push image for github container repository with commit SHA
-      run: 'docker push controller:latest $GITHUB_REPOSITORY:${{env.GITHUB_SHA}}'
+      run: 'docker push controller:latest $GITHUB_REPOSITORY:$GITHUB_SHA'
 
     - name: Tag image for github container repository with latest
       run: 'docker tag controller:latest $GITHUB_REPOSITORY:latest'


### PR DESCRIPTION
*Description of changes:*

There was a minor syntax issue where the environment variable `GITHUB_SHA` needed to be referenced directly using `$` rather than using the `${{}}` syntax. You cannot directly access the context object (stuff inside ${{}}) inside `run:` and need to get it through environment variables, setting them as needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
