### PR TITLE
Avoid use of reserved env var in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,6 @@
 name: deploy
 
 on:
-  # This is for testing purposes. Will remove prior to merge
-  pull_request:
-    branches: [ main ]
   push:
     branches: [ main ]
 


### PR DESCRIPTION
*Description of changes:*
~_To avoid constantly updating main branch, I am doing some testing in this PR first, will update with final changes once tested._~ **Update: testing complete. Verified that docker image is pushed [successfully!](https://github.com/aws/aws-cloud-map-mcs-controller-for-k8s/runs/3746866468)**

It turns out `GITHUB_REPOSITORY` is a reserved environment variable mapping to the name of the repo. Changing variable to `REGISTRY`

I found a way to test Github Actions locally using [act](https://github.com/nektos/act) so hopefully there will be no more minor updates to these workflows.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
