### PR TITLE
Fix the make build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ e2e-test: manifests kustomize kubetest2 fmt vet
 
 ##@ Build
 
-build: generate fmt vet ## Build manager binary.
+build: manifests generate generate-mocks fmt vet ## Build manager binary.
 	go build -o bin/manager main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.


### PR DESCRIPTION
`make build` fails because of missing mocks. Adding the `generate-mocks` step to the build.

```
pkg/controllers/serviceexport_controller_test.go:6:2: no required module provides package github.com/aws/aws-cloud-map-mcs-controller-for-k8s/mocks/pkg/cloudmap; to add it:
	go get github.com/aws/aws-cloud-map-mcs-controller-for-k8s/mocks/pkg/cloudmap
make: *** [vet] Error 1
```
