### PR TITLE
Add config needed to deploy from remote registry

### DIFF
--- a/config/controller_install_latest/kustomization.yaml
+++ b/config/controller_install_latest/kustomization.yaml
@@ -1,0 +1,7 @@
+bases:
+- ../default
+
+images:
+- name: controller
+  newName: ghcr.io/aws/aws-cloud-map-mcs-controller-for-k8s
+  newTag: latest


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding kustomize config to enable installing from [registry](https://github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkgs/container/aws-cloud-map-mcs-controller-for-k8s)

To install run (once both code and docker images are public) `kubectl apply -k github.com/aws/aws-cloud-map-mcs-controller-for-k8s/config/controller_install_latest?ref=<optional commit id, branch, or tag>`

My current thinking is we can have another kustomization that will be tied to the release version image, rather than the latest image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
