### PR TITLE
Extract controller build version using ldflags and store it in Cloud Map

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,11 @@ COPY . ./
 RUN go mod download
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+ENV PKG=github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/version
+RUN GIT_TAG=$(git describe --tags --dirty --always) && \
+    GIT_COMMIT=$(git describe --dirty --always) && \
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build \
+     -ldflags="-s -w -X ${PKG}.GitVersion=${GIT_TAG} -X ${PKG}.GitCommit=${GIT_COMMIT}" -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+GIT_COMMIT:=$(shell git describe --dirty --always)
+GIT_TAG:=$(shell git describe --dirty --always --tags)
+PKG:=github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/version
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
@@ -70,7 +73,7 @@ e2e-test: manifests kustomize kubetest2 fmt vet
 ##@ Build
 
 build: manifests generate generate-mocks fmt vet ## Build manager binary.
-	go build -o bin/manager main.go
+	go build -ldflags="-s -w -X ${PKG}.GitVersion=${GIT_TAG} -X ${PKG}.GitCommit=${GIT_COMMIT}" -o bin/manager main.go
 
 run: manifests generate generate-mocks fmt vet ## Run a controller from your host.
 	go run ./main.go

--- a/main.go
+++ b/main.go
@@ -19,10 +19,10 @@ package main
 import (
 	"context"
 	"flag"
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/cloudmap"
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/version"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"os"
-
-	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/cloudmap"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -68,6 +68,9 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	v := version.GetVersion()
+	setupLog.Info("starting AWS Cloud Map MCS Controller for K8s", "version", v)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,

--- a/pkg/controllers/serviceexport_controller.go
+++ b/pkg/controllers/serviceexport_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/cloudmap"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/version"
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
@@ -198,12 +199,17 @@ func (r *ServiceExportReconciler) extractEndpoints(ctx context.Context, svc *v1.
 		for _, port := range slice.Ports {
 			for _, ep := range slice.Endpoints {
 				for _, IP := range ep.Addresses {
+					attributes := make(map[string]string, 0)
+					if version.GetVersion() != "" {
+						attributes["K8S_CONTROLLER"] = version.PackageName + " " + version.GetVersion()
+					}
+					// TODO extract attributes - pod, node and other useful details if possible
+
 					result = append(result, &model.Endpoint{
 						Id:         model.EndpointIdFromIPAddress(IP),
 						IP:         IP,
 						Port:       *port.Port,
-						Attributes: make(map[string]string, 0),
-						// TODO extract attributes - pod, node and other useful details if possible
+						Attributes: attributes,
 					})
 				}
 			}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,24 @@
+package version
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Build information obtained with the help of -ldflags
+var (
+	GitVersion  string
+	GitCommit   string
+	PackageName = "aws-cloud-map-mcs-controller-for-k8s"
+)
+
+// GetVersion figures out the version information
+// based on variables set by -ldflags.
+func GetVersion() string {
+	// only set the appVersion if -ldflags was used
+	if GitCommit != "" {
+		return fmt.Sprintf("%s (%s)", strings.TrimPrefix(GitVersion, "v"), GitCommit)
+	}
+
+	return ""
+}


### PR DESCRIPTION
Using `ldflags` to inject git commit and tag during build time. Controller version is in format `GIT_TAG (GIT_COMMIT)`, for example `0.1.0 (2fe24b4)`. Version attribute is stored with each Cloud Map instance for debug purposes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
