### PR TITLE
Fix namespace id cache

### DIFF
--- a/pkg/cloudmap/client.go
+++ b/pkg/cloudmap/client.go
@@ -249,12 +249,14 @@ func (sdc *serviceDiscoveryClient) getNamespaceId(ctx context.Context, nsName st
 	}
 
 	for _, ns := range namespaces {
-		sdc.cacheNamespaceId(nsName, nsId)
+		sdc.cacheNamespaceId(ns.Name, ns.Id)
 		if nsName == ns.Name {
 			nsId = ns.Id
 		}
 	}
 
+	// This will cache empty namespace IDs for namespaces not in Cloud Map
+	sdc.cacheNamespaceId(nsName, nsId)
 	return nsId, nil
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Stop cacheing empty namespace ID if found in Cloud Map, and cache all namespaces in account. Continue to cache empty ID if not found to prevent throttling for non-imported services.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
