### PR TITLE
Refactor client interface for service structs

### DIFF
--- a/pkg/cloudmap/client_test.go
+++ b/pkg/cloudmap/client_test.go
@@ -1,0 +1,278 @@
+package cloudmap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/mocks/pkg/cloudmap"
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/test"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	testing2 "github.com/go-logr/logr/testing"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/cache"
+	"testing"
+	"time"
+)
+
+func TestNewServiceDiscoveryClient(t *testing.T) {
+	sdc := NewServiceDiscoveryClient(&aws.Config{})
+	assert.NotNil(t, sdc)
+}
+
+func TestServiceDiscoveryClient_ListServices_HappyCase(t *testing.T) {
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
+	sdApi.EXPECT().ListNamespaces(context.TODO()).
+		Return([]*model.Resource{{Name: test.NsName, Id: test.NsId}}, nil)
+	sdApi.EXPECT().ListServices(context.TODO(), test.NsId).
+		Return([]*model.Resource{{Name: test.SvcName, Id: test.SvcId}}, nil)
+	sdApi.EXPECT().ListInstances(context.TODO(), test.SvcId).
+		Return([]*model.Endpoint{test.GetTestEndpoint()}, nil)
+
+	sdc := getTestSdClient(t, sdApi)
+	svcs, err := sdc.ListServices(context.TODO(), test.NsName)
+	assert.Equal(t, []*model.Service{test.GetTestService()}, svcs)
+	assert.Nil(t, err, "No error for happy case")
+
+	cachedNs, _ := sdc.namespaceIdCache.Get(test.NsName)
+	assert.Equal(t, test.NsId, cachedNs, "Happy case caches namespace ID")
+	cachedSvc, _ := sdc.serviceIdCache.Get(fmt.Sprintf("%s/%s", test.NsName, test.SvcName))
+	assert.Equal(t, test.SvcId, cachedSvc, "Happy case caches service ID")
+	cachedEndpts, _ := sdc.endpointCache.Get(test.SvcId)
+	assert.Equal(t, []*model.Endpoint{test.GetTestEndpoint()}, cachedEndpts, "Happy case caches endpoints")
+}
+
+func TestServiceDiscoveryClient_ListServices_HappyCaseCachedResults(t *testing.T) {
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
+	sdApi.EXPECT().ListServices(context.TODO(), test.NsId).
+		Return([]*model.Resource{{Name: test.SvcName, Id: test.SvcId}}, nil)
+
+	sdc := getTestSdClient(t, sdApi)
+	sdc.namespaceIdCache.Add(test.NsName, test.NsId, time.Minute)
+	sdc.endpointCache.Add(test.SvcId, []*model.Endpoint{test.GetTestEndpoint()}, time.Minute)
+
+	svcs, err := sdc.ListServices(context.TODO(), test.NsName)
+	assert.Equal(t, []*model.Service{test.GetTestService()}, svcs)
+	assert.Nil(t, err, "No error for happy case")
+}
+
+func TestServiceDiscoveryClient_ListServices_NamespaceError(t *testing.T) {
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	nsErr := errors.New("error listing namespaces")
+	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
+	sdApi.EXPECT().ListNamespaces(context.TODO()).
+		Return([]*model.Resource{}, nsErr)
+
+	sdc := getTestSdClient(t, sdApi)
+	svcs, err := sdc.ListServices(context.TODO(), test.NsName)
+	assert.Equal(t, nsErr, err)
+	assert.Empty(t, svcs)
+}
+
+func TestServiceDiscoveryClient_ListServices_ServiceError(t *testing.T) {
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	svcErr := errors.New("error listing services")
+
+	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
+	sdApi.EXPECT().ListNamespaces(context.TODO()).
+		Return([]*model.Resource{{Name: test.NsName, Id: test.NsId}}, nil)
+	sdApi.EXPECT().ListServices(context.TODO(), test.NsId).
+		Return([]*model.Resource{}, svcErr)
+
+	sdc := getTestSdClient(t, sdApi)
+	svcs, err := sdc.ListServices(context.TODO(), test.NsName)
+	assert.Equal(t, svcErr, err)
+	assert.Empty(t, svcs)
+}
+
+func TestServiceDiscoveryClient_ListServices_InstanceError(t *testing.T) {
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	endptErr := errors.New("error listing endpoints")
+	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
+	sdApi.EXPECT().ListNamespaces(context.TODO()).
+		Return([]*model.Resource{{Name: test.NsName, Id: test.NsId}}, nil)
+	sdApi.EXPECT().ListServices(context.TODO(), test.NsId).
+		Return([]*model.Resource{{Name: test.SvcName, Id: test.SvcId}}, nil)
+	sdApi.EXPECT().ListInstances(context.TODO(), test.SvcId).
+		Return([]*model.Endpoint{}, endptErr)
+
+	sdc := getTestSdClient(t, sdApi)
+	svcs, err := sdc.ListServices(context.TODO(), test.NsName)
+	assert.Equal(t, endptErr, err)
+	assert.Empty(t, svcs)
+}
+
+func TestServiceDiscoveryClient_ListServices_NamespaceNotFound(t *testing.T) {
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
+	sdApi.EXPECT().ListNamespaces(context.TODO()).
+		Return([]*model.Resource{}, nil)
+
+	sdc := getTestSdClient(t, sdApi)
+	svcs, err := sdc.ListServices(context.TODO(), test.NsName)
+	assert.Empty(t, svcs)
+	assert.Nil(t, err, "No error for namespace not found")
+
+	cachedNs, found := sdc.namespaceIdCache.Get(test.NsName)
+	assert.True(t, found)
+	assert.Equal(t, "", cachedNs, "Namespace not found caches empty ID")
+}
+
+func TestServiceDiscoveryClient_CreateService_HappyCase(t *testing.T) {
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
+	sdApi.EXPECT().ListNamespaces(context.TODO()).
+		Return([]*model.Resource{{Name: test.NsName, Id: test.NsId}}, nil)
+	sdApi.EXPECT().CreateService(context.TODO(), test.NsId, test.SvcName).
+		Return(test.SvcId, nil)
+
+	sdc := getTestSdClient(t, sdApi)
+	err := sdc.CreateService(context.TODO(), test.NsName, test.SvcName)
+	assert.Nil(t, err, "No error for happy case")
+
+	cachedNs, _ := sdc.namespaceIdCache.Get(test.NsName)
+	assert.Equal(t, test.NsId, cachedNs, "Happy case caches namespace ID")
+	cachedSvc, _ := sdc.serviceIdCache.Get(fmt.Sprintf("%s/%s", test.NsName, test.SvcName))
+	assert.Equal(t, test.SvcId, cachedSvc, "Happy case caches service ID")
+}
+
+func TestServiceDiscoveryClient_CreateService_HappyCaseCachedResults(t *testing.T) {
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
+	sdApi.EXPECT().CreateService(context.TODO(), test.NsId, test.SvcName).
+		Return(test.SvcId, nil)
+
+	sdc := getTestSdClient(t, sdApi)
+	sdc.namespaceIdCache.Add(test.NsName, test.NsId, time.Minute)
+
+	err := sdc.CreateService(context.TODO(), test.NsName, test.SvcName)
+	assert.Nil(t, err, "No error for happy case")
+}
+
+func TestServiceDiscoveryClient_CreateService_NamespaceError(t *testing.T) {
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	nsErr := errors.New("error listing namespaces")
+	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
+	sdApi.EXPECT().ListNamespaces(context.TODO()).
+		Return([]*model.Resource{}, nsErr)
+
+	sdc := getTestSdClient(t, sdApi)
+	err := sdc.CreateService(context.TODO(), test.NsName, test.SvcName)
+	assert.Equal(t, nsErr, err)
+}
+
+func TestServiceDiscoveryClient_CreateService_CreateServiceError(t *testing.T) {
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	svcErr := errors.New("error creating service")
+	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
+	sdApi.EXPECT().ListNamespaces(context.TODO()).
+		Return([]*model.Resource{{Name: test.NsName, Id: test.NsId}}, nil)
+	sdApi.EXPECT().CreateService(context.TODO(), test.NsId, test.SvcName).
+		Return("", svcErr)
+
+	sdc := getTestSdClient(t, sdApi)
+	err := sdc.CreateService(context.TODO(), test.NsName, test.SvcName)
+	assert.Equal(t, err, svcErr)
+}
+
+func TestServiceDiscoveryClient_CreateService_CreatesNamespace_HappyCase(t *testing.T) {
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
+	sdc := getTestSdClient(t, sdApi)
+
+	sdApi.EXPECT().ListNamespaces(context.TODO()).
+		Return([]*model.Resource{}, nil)
+	sdApi.EXPECT().CreateHttpNamespace(context.TODO(), test.NsName).
+		Return(test.OpId1, nil)
+	sdApi.EXPECT().PollCreateNamespace(context.TODO(), test.OpId1).
+		Return(test.NsId, nil)
+	sdApi.EXPECT().CreateService(context.TODO(), test.NsId, test.SvcName).
+		Return(test.SvcId, nil)
+
+	err := sdc.CreateService(context.TODO(), test.NsName, test.SvcName)
+	assert.Nil(t, err, "No error for happy case")
+
+	cachedNs, _ := sdc.namespaceIdCache.Get(test.NsName)
+	assert.Equal(t, test.NsId, cachedNs, "Create namespace caches namespace ID")
+}
+
+func TestServiceDiscoveryClient_CreateService_CreatesNamespace_PollError(t *testing.T) {
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	pollErr := errors.New("polling error")
+	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
+	sdApi.EXPECT().ListNamespaces(context.TODO()).
+		Return([]*model.Resource{}, nil)
+	sdApi.EXPECT().CreateHttpNamespace(context.TODO(), test.NsName).
+		Return(test.OpId1, nil)
+	sdApi.EXPECT().PollCreateNamespace(context.TODO(), test.OpId1).
+		Return("", pollErr)
+
+	sdc := getTestSdClient(t, sdApi)
+	err := sdc.CreateService(context.TODO(), test.NsName, test.SvcName)
+	assert.Equal(t, pollErr, err)
+}
+
+func TestServiceDiscoveryClient_CreateService_CreatesNamespace_CreateNsError(t *testing.T) {
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	nsErr := errors.New("create namespace error")
+	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
+	sdApi.EXPECT().ListNamespaces(context.TODO()).
+		Return([]*model.Resource{}, nil)
+	sdApi.EXPECT().CreateHttpNamespace(context.TODO(), test.NsName).
+		Return("", nsErr)
+
+	sdc := getTestSdClient(t, sdApi)
+	err := sdc.CreateService(context.TODO(), test.NsName, test.SvcName)
+	assert.Equal(t, nsErr, err)
+}
+
+func TestServiceDiscoveryClient_GetService(t *testing.T) {
+	// TODO: Add unit tests
+}
+
+func TestServiceDiscoveryClient_RegisterEndpoints(t *testing.T) {
+	// TODO: Add unit tests
+}
+
+func TestServiceDiscoveryClient_DeleteEndpoints(t *testing.T) {
+	// TODO: Add unit tests
+}
+
+func getTestSdClient(t *testing.T, sdApi ServiceDiscoveryApi) serviceDiscoveryClient {
+	return serviceDiscoveryClient{
+		log:              testing2.TestLogger{T: t},
+		sdApi:            sdApi,
+		namespaceIdCache: cache.NewLRUExpireCache(1024),
+		serviceIdCache:   cache.NewLRUExpireCache(1024),
+		endpointCache:    cache.NewLRUExpireCache(1024),
+	}
+}

--- a/pkg/controllers/serviceexport_controller_test.go
+++ b/pkg/controllers/serviceexport_controller_test.go
@@ -37,9 +37,10 @@ func TestServiceExportReconciler_Reconcile_NewServiceExport(t *testing.T) {
 
 	cloudmapMock := cloudmapmock.NewMockServiceDiscoveryClient(mockController)
 	// expected interactions with the Cloud Map client
-	cloudmapMock.EXPECT().GetService(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-	cloudmapMock.EXPECT().CreateService(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-	cloudmapMock.EXPECT().RegisterEndpoints(gomock.Any(), gomock.Eq(&expectedService)).Return(nil).Times(1)
+	cloudmapMock.EXPECT().GetService(gomock.Any(), expectedService.Namespace, expectedService.Name).Return(nil, nil)
+	cloudmapMock.EXPECT().CreateService(gomock.Any(), expectedService.Namespace, expectedService.Name).Return(nil).Times(1)
+	cloudmapMock.EXPECT().RegisterEndpoints(gomock.Any(), expectedService.Namespace, expectedService.Name,
+		expectedService.Endpoints).Return(nil).Times(1)
 
 	reconciler := setupServiceExportReconciler(t, cloudmapMock)
 
@@ -82,7 +83,8 @@ func TestServiceExportReconciler_Reconcile_ExistingServiceNewEndpoint(t *testing
 
 	// expected interactions with the Cloud Map client
 	cloudmapMock.EXPECT().GetService(gomock.Any(), gomock.Any(), gomock.Any()).Return(&emptyService, nil)
-	cloudmapMock.EXPECT().RegisterEndpoints(gomock.Any(), gomock.Eq(&expectedService)).Return(nil).Times(1)
+	cloudmapMock.EXPECT().RegisterEndpoints(gomock.Any(), expectedService.Namespace, expectedService.Name,
+		expectedService.Endpoints).Return(nil).Times(1)
 
 	request := ctrl.Request{
 		NamespacedName: types.NamespacedName{

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -10,18 +10,20 @@ import (
 	"strings"
 )
 
-// Resource encapsulates a ID/name pair
+// Resource encapsulates a ID/name pair.
 type Resource struct {
 	Id   string
 	Name string
 }
 
+// Service holds namespace and endpoint state for a named service.
 type Service struct {
 	Namespace string
 	Name      string
 	Endpoints []*Endpoint
 }
 
+// Endpoint holds basic values and attributes for an endpoint.
 type Endpoint struct {
 	Id         string
 	IP         string
@@ -34,7 +36,7 @@ const (
 	PortAttr = "AWS_INSTANCE_PORT"
 )
 
-// NewEndpointFromInstance converts a Cloud Map InstanceSummary to an endpoint
+// NewEndpointFromInstance converts a Cloud Map InstanceSummary to an endpoint.
 func NewEndpointFromInstance(inst *types.InstanceSummary) (*Endpoint, error) {
 	endpoint := Endpoint{
 		Id:         *inst.Id,
@@ -68,7 +70,7 @@ func NewEndpointFromInstance(inst *types.InstanceSummary) (*Endpoint, error) {
 	return &endpoint, nil
 }
 
-// GetCloudMapAttributes extracts endpoint attributes for Cloud Map service instance registration
+// GetCloudMapAttributes extracts endpoint attributes for Cloud Map service instance registration.
 func (e *Endpoint) GetCloudMapAttributes() map[string]string {
 	attrs := make(map[string]string, 0)
 
@@ -84,11 +86,12 @@ func (e *Endpoint) GetCloudMapAttributes() map[string]string {
 	return attrs
 }
 
-// Equals evaluates if two Endpoints are "deeply equal" (including all fields)
+// Equals evaluates if two Endpoints are "deeply equal" (including all fields).
 func (e *Endpoint) Equals(other *Endpoint) bool {
 	return reflect.DeepEqual(e, other)
 }
 
+// String gives a string representation for an endpoint.
 func (e *Endpoint) String() string {
 	bytes, err := json.Marshal(e)
 	if err != nil {
@@ -98,7 +101,7 @@ func (e *Endpoint) String() string {
 	return string(bytes)
 }
 
-// EndpointIdFromIPAddress converts an IP address to human readable identifier
+// EndpointIdFromIPAddress converts an IP address to human readable identifier.
 func EndpointIdFromIPAddress(address string) string {
 	return strings.Replace(address, ".", "_", -1)
 }

--- a/test/test-constants.go
+++ b/test/test-constants.go
@@ -1,0 +1,34 @@
+package test
+
+import "github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
+
+const (
+	NsName     = "ns-name"
+	NsId       = "ns-id"
+	SvcName    = "svc-name"
+	SvcId      = "svc-id"
+	EndptId1   = "endpoint-id-1"
+	EndptIp1   = "endpoint-ip-1"
+	EndptPort1 = 2
+	OpId1      = "operation-id-1"
+	OpId2      = "operation-id-2"
+	OpStart    = 1
+)
+
+func GetTestService() *model.Service {
+	endPt := GetTestEndpoint()
+	return &model.Service{
+		Namespace: NsName,
+		Name:      SvcName,
+		Endpoints: []*model.Endpoint{endPt},
+	}
+}
+
+func GetTestEndpoint() *model.Endpoint {
+	return &model.Endpoint{
+		Id:         EndptId1,
+		IP:         EndptIp1,
+		Port:       EndptPort1,
+		Attributes: make(map[string]string, 0),
+	}
+}


### PR DESCRIPTION
*Issue #34:*

*Description of changes:*
Pass values directly to cloud map resource mutating client functions for clarity.
Fixed a ListServices bug that would not return a list endpoints error.
Add a bunch of unit tests.
Move test constants to separate file to avoid package pollution.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
