### PR TITLE
Added additional permissions to the ClusterRole

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -28,7 +28,31 @@ rules:
   resources:
   - serviceimports
   verbs:
+  - create
   - get
   - list
   - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+  - get
+  - create
   - update


### PR DESCRIPTION
*Issue #, if available:*
No issue # associated
*Description of changes:*
The ClusterRole named manager-role does not contain the appropriate permissions so the user will experience a number of errors. After running the controller, I took each error and added to the manager-role so that there's no permission errors when installing the controller. 

Examples of error messages include:
```
E1019 22:48:05.025308       1 reflector.go:127] pkg/mod/k8s.io/client-go@v0.19.2/tools/cache/reflector.go:156: Failed to watch *v1alpha1.ServiceImport: unknown (get serviceimports.multicluster.x-k8s.io)

E1019 23:01:32.562511       1 reflector.go:127] pkg/mod/k8s.io/client-go@v0.19.2/tools/cache/reflector.go:156: Failed to watch *v1.Service: failed to list *v1.Service: services is forbidden: User "system:serviceaccount:migration-system:migration-controller-manager" cannot list resource "services" in API group "" at the cluster scope

E1019 23:05:14.435883       1 reflector.go:127] pkg/mod/k8s.io/client-go@v0.19.2/tools/cache/reflector.go:156: Failed to watch *v1beta1.EndpointSlice: failed to list *v1beta1.EndpointSlice: endpointslices.discovery.k8s.io is forbidden: User "system:serviceaccount:migration-system:migration-controller-manager" cannot list resource "endpointslices" in API group "discovery.k8s.io" at the cluster scope

2021-10-19T23:30:54.044Z        ERROR   controllers.CloudMap    error when syncing service      {"namespace": "demo", "name": "demo-service", "error": "serviceimports.multicluster.x-k8s.io is forbidden: User \"system:serviceaccount:migration-system:migration-controller-manager\" cannot create resource \"serviceimports\" in API group \"multicluster.x-k8s.io\" in the namespace \"demo\""}
github.com/go-logr/zapr.(*zapLogger).Error

2021-10-19T23:33:01.038Z        ERROR   controllers.CloudMap    error when syncing service      {"namespace": "demo", "name": "demo-service", "error": "services is forbidden: User \"system:serviceaccount:migration-system:migration-controller-manager\" cannot create resource \"services\" in API group \"\" in the namespace \"demo\""}

2021-10-19T23:52:20.854Z        ERROR   controllers.CloudMap    error when syncing service      {"namespace": "demo", "name": "demo-service", "error": "endpointslices.discovery.k8s.io is forbidden: User \"system:serviceaccount:migration-system:migration-controller-manager\" cannot create resource \"endpointslices\" in API group \"discovery.k8s.io\" in the namespace \"demo\""}
github.com/go-logr/zapr.(*zapLogger).Error

2021-10-20T22:55:14.177Z        ERROR   controllers.CloudMap    error when syncing service      {"namespace": "demo", "name": "demo-service", "error": "serviceimports.multicluster.x-k8s.io is forbidden: User \"system:serviceaccount:migration-system:migration-controller-manager\" cannot create resource \"serviceimports\" in API group \"multicluster.x-k8s.io\" in the namespace \"demo\""}

E1020 23:00:24.728275       1 reflector.go:127] pkg/mod/k8s.io/client-go@v0.19.2/tools/cache/reflector.go:156: Failed to watch *v1.Service: failed to list *v1.Service: services is forbidden: User "system:serviceaccount:migration-system:migration-controller-manager" cannot list resource "services" in API group "" at the cluster scope

E1020 23:03:16.843445       1 reflector.go:127] pkg/mod/k8s.io/client-go@v0.19.2/tools/cache/reflector.go:156: Failed to watch *v1beta1.EndpointSlice: failed to list *v1beta1.EndpointSlice: endpointslices.discovery.k8s.io is forbidden: User "system:serviceaccount:migration-system:migration-controller-manager" cannot list resource "endpointslices" in API group "discovery.k8s.io" at the cluster scope
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
