### PR TITLE
Fix controllers RBAC permissions

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,12 +1,12 @@
 # Adds namespace to all resources.
-namespace: migration-system
+namespace: cloud-map-mcs-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: migration-
+namePrefix: cloud-map-mcs-
 
 # Labels to add to all resources and selectors.
 #commonLabels:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,31 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
   - multicluster.x-k8s.io
   resources:
   - serviceexports
@@ -29,30 +54,9 @@ rules:
   - serviceimports
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
   - update
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  - services
-  - endpoints
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-- apiGroups:
-  - discovery.k8s.io
-  resources:
-  - endpointslices
-  verbs:
-  - list
-  - watch
-  - get
-  - create
-  - update

--- a/pkg/controllers/cloudmap_controller.go
+++ b/pkg/controllers/cloudmap_controller.go
@@ -34,7 +34,10 @@ type CloudMapReconciler struct {
 	logr.Logger
 }
 
-// +kubebuilder:rbac:groups=multicluster.x-k8s.io,resources=serviceimports,verbs=get;list;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=list;watch
+// +kubebuilder:rbac:groups="",resources=services,verbs=create;get;list;watch
+// +kubebuilder:rbac:groups="discovery.k8s.io",resources=endpointslices,verbs=list;get;create;watch
+// +kubebuilder:rbac:groups=multicluster.x-k8s.io,resources=serviceimports,verbs=create;get;list;watch;update;patch;delete
 
 // Start implements manager.Runnable
 func (r *CloudMapReconciler) Start(ctx context.Context) error {

--- a/pkg/controllers/serviceexport_controller.go
+++ b/pkg/controllers/serviceexport_controller.go
@@ -47,6 +47,8 @@ type ServiceExportReconciler struct {
 	Cloudmap cloudmap.ServiceDiscoveryClient
 }
 
+// +kubebuilder:rbac:groups="",resources=services,verbs=get
+// +kubebuilder:rbac:groups="discovery.k8s.io",resources=endpointslices,verbs=list;watch;create
 // +kubebuilder:rbac:groups=multicluster.x-k8s.io,resources=serviceexports,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=multicluster.x-k8s.io,resources=serviceexports/finalizers,verbs=get;update
 


### PR DESCRIPTION
Closes #41

Fixing controllers permission using kubebuilder markers. Cluster role is generated based on that during build.

https://book.kubebuilder.io/reference/markers/rbac.html