### PR TITLE
Fix multiple instance registration/deregistration

### DIFF
--- a/pkg/cloudmap/client.go
+++ b/pkg/cloudmap/client.go
@@ -157,8 +157,10 @@ func (sdc *serviceDiscoveryClient) RegisterEndpoints(ctx context.Context, nsName
 	opCollector := NewOperationCollector()
 
 	for _, endpt := range endpts {
+		endptId := endpt.Id
+		endptAttrs := endpt.GetCloudMapAttributes()
 		opCollector.Add(func() (opId string, err error) {
-			return sdc.sdApi.RegisterInstance(ctx, svcId, endpt.Id, endpt.GetCloudMapAttributes())
+			return sdc.sdApi.RegisterInstance(ctx, svcId, endptId, endptAttrs)
 		})
 	}
 
@@ -195,8 +197,9 @@ func (sdc *serviceDiscoveryClient) DeleteEndpoints(ctx context.Context, nsName s
 	opCollector := NewOperationCollector()
 
 	for _, endpt := range endpts {
+		endptId := endpt.Id
 		opCollector.Add(func() (opId string, err error) {
-			return sdc.sdApi.DeregisterInstance(ctx, svcId, endpt.Id)
+			return sdc.sdApi.DeregisterInstance(ctx, svcId, endptId)
 		})
 	}
 

--- a/pkg/controllers/cloudmap_controller.go
+++ b/pkg/controllers/cloudmap_controller.go
@@ -27,8 +27,7 @@ const (
 	// DerivedServiceAnnotation annotates a ServiceImport with derived Service name
 	DerivedServiceAnnotation = "multicluster.k8s.aws/derived-service"
 
-	// LabelServiceName is used to indicate the name of multi-cluster service
-	// that an EndpointSlice belongs to.
+	// LabelServiceImportName indicates the name of multi-cluster service that an EndpointSlice belongs to.
 	LabelServiceImportName = "multicluster.kubernetes.io/service-name"
 )
 

--- a/test/test-constants.go
+++ b/test/test-constants.go
@@ -12,8 +12,11 @@ const (
 	EndptId1      = "endpoint-id-1"
 	EndptId2      = "endpoint-id-2"
 	EndptIp1      = "192.168.0.1"
-	EndptPort1    = 2
-	EndptPortStr1 = "2"
+	EndptIp2      = "192.168.0.2"
+	EndptPort1    = 1
+	EndptPortStr1 = "1"
+	EndptPort2    = 2
+	EndptPortStr2 = "2"
 	OpId1         = "operation-id-1"
 	OpId2         = "operation-id-2"
 	OpStart       = 1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Pass value into register/de-register instance functions. Prior behaviour passed a reference to the iterator struct, which caused multiple calls for the same instance id.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
