### PR TITLE
Fix get namespace iterator pointer

### DIFF
--- a/pkg/cloudmap/client.go
+++ b/pkg/cloudmap/client.go
@@ -257,11 +257,12 @@ func (sdc *serviceDiscoveryClient) getNamespace(ctx context.Context, nsName stri
 		return nil, err
 	}
 
-	for _, ns := range namespaces {
-		sdc.cacheNamespace(*ns)
+	for _, itPtr := range namespaces {
+		ns := *itPtr
+		sdc.cacheNamespace(ns)
 		// Set the return namespace
 		if nsName == ns.Name {
-			namespace = ns
+			namespace = &ns
 		}
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
De-reference namespace iterator pointer to prevent returning wrong namespace.
Pushing as hot fix, following up with test improvements to ensure list functions are tested against multiple values.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
