### PR TITLE
Extract Cloud Map client cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 MOCKS_DESTINATION=mocks
 generate-mocks: mockgen
 	$(MOCKGEN) --source pkg/cloudmap/client.go --destination $(MOCKS_DESTINATION)/pkg/cloudmap/client_mock.go --package cloudmap
+	$(MOCKGEN) --source pkg/cloudmap/cache.go --destination $(MOCKS_DESTINATION)/pkg/cloudmap/cache_mock.go --package cloudmap
 	$(MOCKGEN) --source pkg/cloudmap/operation_poller.go --destination $(MOCKS_DESTINATION)/pkg/cloudmap/operation_poller_mock.go --package cloudmap
 	$(MOCKGEN) --source pkg/cloudmap/operation_collector.go --destination $(MOCKS_DESTINATION)/pkg/cloudmap/operation_collector_mock.go --package cloudmap
 	$(MOCKGEN) --source pkg/cloudmap/api.go --destination $(MOCKS_DESTINATION)/pkg/cloudmap/api_mock.go --package cloudmap

--- a/pkg/cloudmap/cache.go
+++ b/pkg/cloudmap/cache.go
@@ -1,6 +1,7 @@
 package cloudmap
 
 import (
+	"errors"
 	"fmt"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
 	"github.com/go-logr/logr"
@@ -67,7 +68,7 @@ func (sdCache *sdCache) GetNamespace(nsName string) (ns *model.Namespace, found 
 
 	nsEntry, ok := entry.(model.Namespace)
 	if !ok {
-		sdCache.log.Info("failed to retrieve namespace from cache", "nsName", nsName)
+		sdCache.log.Error(errors.New("failed to retrieve namespace from cache"), "", "nsName", nsName)
 		sdCache.cache.Remove(key)
 		return nil, false
 	}
@@ -94,7 +95,7 @@ func (sdCache *sdCache) GetServiceId(nsName string, svcName string) (svcId strin
 
 	svcId, ok := entry.(string)
 	if !ok {
-		sdCache.log.Info("failed to retrieve service ID from cache",
+		sdCache.log.Error(errors.New("failed to retrieve service ID from cache"), "",
 			"nsName", nsName, "svcName", svcName)
 		sdCache.cache.Remove(key)
 		return "", false
@@ -117,7 +118,7 @@ func (sdCache *sdCache) GetEndpoints(svcId string) (endpts []*model.Endpoint, fo
 
 	endpts, ok := entry.([]*model.Endpoint)
 	if !ok {
-		sdCache.log.Info("failed to retrieve endpoints from cache", "svcId", svcId)
+		sdCache.log.Error(errors.New("failed to retrieve endpoints from cache"), "", "svcId", svcId)
 		sdCache.cache.Remove(key)
 		return nil, false
 	}
@@ -136,13 +137,13 @@ func (sdCache *sdCache) EvictEndpoints(svcId string) {
 }
 
 func (sdCache *sdCache) buildNsKey(nsName string) (cacheKey string) {
-	return fmt.Sprintf("%s_%s", nsKeyPrefix, nsName)
+	return fmt.Sprintf("%s:%s", nsKeyPrefix, nsName)
 }
 
 func (sdCache *sdCache) buildSvcKey(nsName string, svcName string) (cacheKey string) {
-	return fmt.Sprintf("%s_%s/%s", svcKeyPrefix, nsName, svcName)
+	return fmt.Sprintf("%s:%s:%s", svcKeyPrefix, nsName, svcName)
 }
 
 func (sdCache *sdCache) buildEndptsKey(svcId string) string {
-	return fmt.Sprintf("%s_%s", endptKeyPrefix, svcId)
+	return fmt.Sprintf("%s:%s", endptKeyPrefix, svcId)
 }

--- a/pkg/cloudmap/cache.go
+++ b/pkg/cloudmap/cache.go
@@ -1,0 +1,148 @@
+package cloudmap
+
+import (
+	"fmt"
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/util/cache"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"time"
+)
+
+const (
+	nsKeyPrefix    = "ns"
+	svcKeyPrefix   = "svc"
+	endptKeyPrefix = "endpt"
+
+	defaultCacheSize = 1024
+	defaultNsTTL     = 2 * time.Minute
+	defaultSvcTTL    = 2 * time.Minute
+	defaultEndptTTL  = 5 * time.Second
+)
+
+type ServiceDiscoveryClientCache interface {
+	GetNamespace(namespaceName string) (namespace *model.Namespace, found bool)
+	CacheNamespace(namespace *model.Namespace)
+	CacheNilNamespace(namespaceName string)
+	GetServiceId(namespaceName string, serviceName string) (serviceId string, found bool)
+	CacheServiceId(namespaceName string, serviceName string, serviceId string)
+	GetEndpoints(serviceId string) (endpoints []*model.Endpoint, found bool)
+	CacheEndpoints(serviceId string, endpoints []*model.Endpoint)
+	EvictEndpoints(serviceId string)
+}
+
+type sdCache struct {
+	log    logr.Logger
+	cache  *cache.LRUExpireCache
+	config sdCacheConfig
+}
+
+type sdCacheConfig struct {
+	nsTTL    time.Duration
+	svcTTL   time.Duration
+	endptTTL time.Duration
+}
+
+func NewDefaultServiceDiscoveryClientCache() ServiceDiscoveryClientCache {
+	return &sdCache{
+		log:   ctrl.Log.WithName("cloudmap"),
+		cache: cache.NewLRUExpireCache(defaultCacheSize),
+		config: sdCacheConfig{
+			nsTTL:    defaultNsTTL,
+			svcTTL:   defaultSvcTTL,
+			endptTTL: defaultEndptTTL,
+		}}
+}
+
+func (sdCache *sdCache) GetNamespace(nsName string) (ns *model.Namespace, found bool) {
+	key := sdCache.buildNsKey(nsName)
+	entry, exists := sdCache.cache.Get(key)
+	if !exists {
+		return nil, false
+	}
+
+	if entry == nil {
+		return nil, true
+	}
+
+	nsEntry, ok := entry.(model.Namespace)
+	if !ok {
+		sdCache.log.Info("failed to retrieve namespace from cache", "nsName", nsName)
+		sdCache.cache.Remove(key)
+		return nil, false
+	}
+
+	return &nsEntry, true
+}
+
+func (sdCache *sdCache) CacheNamespace(namespace *model.Namespace) {
+	key := sdCache.buildNsKey(namespace.Name)
+	sdCache.cache.Add(key, *namespace, sdCache.config.nsTTL)
+}
+
+func (sdCache *sdCache) CacheNilNamespace(nsName string) {
+	key := sdCache.buildNsKey(nsName)
+	sdCache.cache.Add(key, nil, sdCache.config.nsTTL)
+}
+
+func (sdCache *sdCache) GetServiceId(nsName string, svcName string) (svcId string, found bool) {
+	key := sdCache.buildSvcKey(nsName, svcName)
+	entry, exists := sdCache.cache.Get(key)
+	if !exists {
+		return "", false
+	}
+
+	svcId, ok := entry.(string)
+	if !ok {
+		sdCache.log.Info("failed to retrieve service ID from cache",
+			"nsName", nsName, "svcName", svcName)
+		sdCache.cache.Remove(key)
+		return "", false
+	}
+
+	return svcId, true
+}
+
+func (sdCache *sdCache) CacheServiceId(nsName string, svcName string, svcId string) {
+	key := sdCache.buildSvcKey(nsName, svcName)
+	sdCache.cache.Add(key, svcId, sdCache.config.svcTTL)
+}
+
+func (sdCache *sdCache) GetEndpoints(svcId string) (endpts []*model.Endpoint, found bool) {
+	key := sdCache.buildEndptsKey(svcId)
+	entry, exists := sdCache.cache.Get(key)
+	if !exists {
+		return nil, false
+	}
+
+	endpts, ok := entry.([]*model.Endpoint)
+	if !ok {
+		sdCache.log.Info("failed to retrieve endpoints from cache", "svcId", svcId)
+		sdCache.cache.Remove(key)
+		return nil, false
+	}
+
+	return endpts, true
+}
+
+func (sdCache *sdCache) CacheEndpoints(svcId string, endpts []*model.Endpoint) {
+	key := sdCache.buildEndptsKey(svcId)
+	sdCache.cache.Add(key, endpts, sdCache.config.endptTTL)
+}
+
+func (sdCache *sdCache) EvictEndpoints(svcId string) {
+	key := sdCache.buildEndptsKey(svcId)
+	sdCache.cache.Remove(key)
+}
+
+func (sdCache *sdCache) buildNsKey(nsName string) (cacheKey string) {
+	return fmt.Sprintf("%s_%s", nsKeyPrefix, nsName)
+}
+
+func (sdCache *sdCache) buildSvcKey(nsName string, svcName string) (cacheKey string) {
+	return fmt.Sprintf("%s_%s/%s", svcKeyPrefix, nsName, svcName)
+}
+
+func (sdCache *sdCache) buildEndptsKey(svcId string) string {
+	return fmt.Sprintf("%s_%s", endptKeyPrefix, svcId)
+}

--- a/pkg/cloudmap/cache_test.go
+++ b/pkg/cloudmap/cache_test.go
@@ -96,15 +96,6 @@ func TestServiceDiscoveryClientCacheGetEndpoints_NotFound(t *testing.T) {
 
 func TestServiceDiscoveryClientCacheGetEndpoints_Corrupt(t *testing.T) {
 	sdc := NewDefaultServiceDiscoveryClientCache().(*sdCache)
-	sdc.cache.Add(sdc.buildEndptsKey(test.SvcId), test.GetTestService(), time.Minute)
-
-	ns, found := sdc.GetNamespace(test.NsName)
-	assert.False(t, found)
-	assert.Nil(t, ns)
-}
-
-func TestServiceDiscoveryClientCacheEndpoints(t *testing.T) {
-	sdc := NewDefaultServiceDiscoveryClientCache().(*sdCache)
 
 	sdc.cache.Add(sdc.buildEndptsKey(test.SvcId), &model.Resource{}, time.Minute)
 	endpts, found := sdc.GetEndpoints(test.SvcId)
@@ -113,5 +104,11 @@ func TestServiceDiscoveryClientCacheEndpoints(t *testing.T) {
 }
 
 func TestServiceDiscoveryClientEvictEndpoints(t *testing.T) {
+	sdc := NewDefaultServiceDiscoveryClientCache()
+	sdc.CacheEndpoints(test.SvcId, []*model.Endpoint{test.GetTestEndpoint(), test.GetTestEndpoint2()})
+	sdc.EvictEndpoints(test.SvcId)
 
+	endpts, found := sdc.GetEndpoints(test.SvcId)
+	assert.False(t, found)
+	assert.Nil(t, endpts)
 }

--- a/pkg/cloudmap/cache_test.go
+++ b/pkg/cloudmap/cache_test.go
@@ -1,0 +1,117 @@
+package cloudmap
+
+import (
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/test"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestNewDefaultServiceDiscoveryClientCache(t *testing.T) {
+	sdc := NewDefaultServiceDiscoveryClientCache().(*sdCache)
+
+	assert.Equal(t, defaultNsTTL, sdc.config.nsTTL)
+	assert.Equal(t, defaultSvcTTL, sdc.config.svcTTL)
+	assert.Equal(t, defaultEndptTTL, sdc.config.endptTTL)
+}
+
+func TestServiceDiscoveryClientCacheGetNamespace_Found(t *testing.T) {
+	sdc := NewDefaultServiceDiscoveryClientCache()
+	sdc.CacheNamespace(test.GetTestHttpNamespace())
+
+	ns, found := sdc.GetNamespace(test.NsName)
+	assert.True(t, found)
+	assert.Equal(t, test.GetTestHttpNamespace(), ns)
+}
+
+func TestServiceDiscoveryClientCacheGetNamespace_NotFound(t *testing.T) {
+	sdc := NewDefaultServiceDiscoveryClientCache()
+
+	ns, found := sdc.GetNamespace(test.NsName)
+	assert.False(t, found)
+	assert.Nil(t, ns)
+}
+
+func TestServiceDiscoveryClientCacheGetNamespace_Nil(t *testing.T) {
+	sdc := NewDefaultServiceDiscoveryClientCache()
+	sdc.CacheNilNamespace(test.NsName)
+
+	ns, found := sdc.GetNamespace(test.NsName)
+	assert.True(t, found)
+	assert.Nil(t, ns)
+}
+
+func TestServiceDiscoveryClientCacheGetNamespace_Corrupt(t *testing.T) {
+	sdc := NewDefaultServiceDiscoveryClientCache().(*sdCache)
+	sdc.cache.Add(sdc.buildNsKey(test.NsName), &model.Resource{}, time.Minute)
+
+	ns, found := sdc.GetNamespace(test.NsName)
+	assert.False(t, found)
+	assert.Nil(t, ns)
+}
+
+func TestServiceDiscoveryClientCacheGetServiceId_Found(t *testing.T) {
+	sdc := NewDefaultServiceDiscoveryClientCache()
+	sdc.CacheServiceId(test.NsName, test.SvcName, test.SvcId)
+
+	svcId, found := sdc.GetServiceId(test.NsName, test.SvcName)
+	assert.True(t, found)
+	assert.Equal(t, test.SvcId, svcId)
+}
+
+func TestServiceDiscoveryClientCacheGetServiceId_NotFound(t *testing.T) {
+	sdc := NewDefaultServiceDiscoveryClientCache()
+
+	svcId, found := sdc.GetServiceId(test.NsName, test.SvcName)
+	assert.False(t, found)
+	assert.Empty(t, svcId)
+}
+
+func TestServiceDiscoveryClientCacheGetServiceId_Corrupt(t *testing.T) {
+	sdc := NewDefaultServiceDiscoveryClientCache().(*sdCache)
+
+	sdc.cache.Add(sdc.buildSvcKey(test.NsName, test.SvcName), &model.Resource{}, time.Minute)
+	svcId, found := sdc.GetServiceId(test.NsName, test.SvcName)
+	assert.False(t, found)
+	assert.Empty(t, svcId)
+}
+
+func TestServiceDiscoveryClientCacheGetEndpoints_Found(t *testing.T) {
+	sdc := NewDefaultServiceDiscoveryClientCache()
+	sdc.CacheEndpoints(test.SvcId, []*model.Endpoint{test.GetTestEndpoint(), test.GetTestEndpoint2()})
+
+	endpts, found := sdc.GetEndpoints(test.SvcId)
+	assert.True(t, found)
+	assert.Equal(t, []*model.Endpoint{test.GetTestEndpoint(), test.GetTestEndpoint2()}, endpts)
+}
+
+func TestServiceDiscoveryClientCacheGetEndpoints_NotFound(t *testing.T) {
+	sdc := NewDefaultServiceDiscoveryClientCache()
+
+	endpts, found := sdc.GetEndpoints(test.SvcId)
+	assert.False(t, found)
+	assert.Nil(t, endpts)
+}
+
+func TestServiceDiscoveryClientCacheGetEndpoints_Corrupt(t *testing.T) {
+	sdc := NewDefaultServiceDiscoveryClientCache().(*sdCache)
+	sdc.cache.Add(sdc.buildEndptsKey(test.SvcId), test.GetTestService(), time.Minute)
+
+	ns, found := sdc.GetNamespace(test.NsName)
+	assert.False(t, found)
+	assert.Nil(t, ns)
+}
+
+func TestServiceDiscoveryClientCacheEndpoints(t *testing.T) {
+	sdc := NewDefaultServiceDiscoveryClientCache().(*sdCache)
+
+	sdc.cache.Add(sdc.buildEndptsKey(test.SvcId), &model.Resource{}, time.Minute)
+	endpts, found := sdc.GetEndpoints(test.SvcId)
+	assert.False(t, found)
+	assert.Nil(t, endpts)
+}
+
+func TestServiceDiscoveryClientEvictEndpoints(t *testing.T) {
+
+}

--- a/pkg/cloudmap/client_test.go
+++ b/pkg/cloudmap/client_test.go
@@ -3,7 +3,6 @@ package cloudmap
 import (
 	"context"
 	"errors"
-	"fmt"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/mocks/pkg/cloudmap"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/test"
@@ -12,10 +11,15 @@ import (
 	testing2 "github.com/go-logr/logr/testing"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/util/cache"
 	"testing"
-	"time"
 )
+
+type testSdClient struct {
+	client    *serviceDiscoveryClient
+	mockApi   cloudmap.MockServiceDiscoveryApi
+	mockCache cloudmap.MockServiceDiscoveryClientCache
+	close     func()
+}
 
 func TestNewServiceDiscoveryClient(t *testing.T) {
 	sdc := NewServiceDiscoveryClient(&aws.Config{})
@@ -23,15 +27,20 @@ func TestNewServiceDiscoveryClient(t *testing.T) {
 }
 
 func TestServiceDiscoveryClient_ListServices_HappyCase(t *testing.T) {
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
+	tc := getTestSdClient(t)
+	defer tc.close()
 
-	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
-	sdApi.EXPECT().ListNamespaces(context.TODO()).
+	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(nil, false)
+	tc.mockApi.EXPECT().ListNamespaces(context.TODO()).
 		Return([]*model.Namespace{test.GetTestHttpNamespace()}, nil)
-	sdApi.EXPECT().ListServices(context.TODO(), test.NsId).
+	tc.mockCache.EXPECT().CacheNamespace(test.GetTestHttpNamespace())
+
+	tc.mockApi.EXPECT().ListServices(context.TODO(), test.NsId).
 		Return([]*model.Resource{{Name: test.SvcName, Id: test.SvcId}}, nil)
-	sdApi.EXPECT().ListInstances(context.TODO(), test.SvcId).
+	tc.mockCache.EXPECT().CacheServiceId(test.NsName, test.SvcName, test.SvcId)
+
+	tc.mockCache.EXPECT().GetEndpoints(test.SvcId).Return(nil, false)
+	tc.mockApi.EXPECT().ListInstances(context.TODO(), test.SvcId).
 		Return([]types.InstanceSummary{
 			{
 				Id: aws.String(test.EndptId1),
@@ -48,258 +57,226 @@ func TestServiceDiscoveryClient_ListServices_HappyCase(t *testing.T) {
 				},
 			},
 		}, nil)
+	tc.mockCache.EXPECT().CacheEndpoints(test.SvcId,
+		[]*model.Endpoint{test.GetTestEndpoint(), test.GetTestEndpoint2()})
 
-	sdc := getTestSdClient(t, sdApi)
-	svcs, err := sdc.ListServices(context.TODO(), test.NsName)
+	svcs, err := tc.client.ListServices(context.TODO(), test.NsName)
 	assert.Equal(t, []*model.Service{test.GetTestService()}, svcs)
 	assert.Nil(t, err, "No error for happy case")
-
-	cachedNs, _ := sdc.namespaceCache.Get(test.NsName)
-	assert.Equal(t, *test.GetTestHttpNamespace(), cachedNs, "Happy case caches namespace ID")
-	cachedSvc, _ := sdc.serviceIdCache.Get(fmt.Sprintf("%s/%s", test.NsName, test.SvcName))
-	assert.Equal(t, test.SvcId, cachedSvc, "Happy case caches service ID")
-	cachedEndpts, _ := sdc.endpointCache.Get(test.SvcId)
-	assert.Equal(t, []*model.Endpoint{test.GetTestEndpoint(), test.GetTestEndpoint2()}, cachedEndpts, "Happy case caches endpoints")
 }
 
 func TestServiceDiscoveryClient_ListServices_HappyCaseCachedResults(t *testing.T) {
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
+	tc := getTestSdClient(t)
+	defer tc.close()
 
-	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
-	sdApi.EXPECT().ListServices(context.TODO(), test.NsId).
+	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(test.GetTestHttpNamespace(), true)
+
+	tc.mockApi.EXPECT().ListServices(context.TODO(), test.NsId).
 		Return([]*model.Resource{{Name: test.SvcName, Id: test.SvcId}}, nil)
+	tc.mockCache.EXPECT().CacheServiceId(test.NsName, test.SvcName, test.SvcId)
 
-	sdc := getTestSdClient(t, sdApi)
-	sdc.namespaceCache.Add(test.NsName, *test.GetTestHttpNamespace(), time.Minute)
-	sdc.endpointCache.Add(test.SvcId, []*model.Endpoint{test.GetTestEndpoint(), test.GetTestEndpoint2()}, time.Minute)
+	tc.mockCache.EXPECT().GetEndpoints(test.SvcId).
+		Return([]*model.Endpoint{test.GetTestEndpoint(), test.GetTestEndpoint2()}, true)
 
-	svcs, err := sdc.ListServices(context.TODO(), test.NsName)
+	svcs, err := tc.client.ListServices(context.TODO(), test.NsName)
 	assert.Equal(t, []*model.Service{test.GetTestService()}, svcs)
 	assert.Nil(t, err, "No error for happy case")
 }
 
 func TestServiceDiscoveryClient_ListServices_NamespaceError(t *testing.T) {
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
+	tc := getTestSdClient(t)
+	defer tc.close()
 
 	nsErr := errors.New("error listing namespaces")
-	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
-	sdApi.EXPECT().ListNamespaces(context.TODO()).
-		Return([]*model.Namespace{}, nsErr)
+	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(nil, false)
+	tc.mockApi.EXPECT().ListNamespaces(context.TODO()).
+		Return(nil, nsErr)
 
-	sdc := getTestSdClient(t, sdApi)
-	svcs, err := sdc.ListServices(context.TODO(), test.NsName)
+	svcs, err := tc.client.ListServices(context.TODO(), test.NsName)
 	assert.Equal(t, nsErr, err)
 	assert.Empty(t, svcs)
 }
 
 func TestServiceDiscoveryClient_ListServices_ServiceError(t *testing.T) {
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
+	tc := getTestSdClient(t)
+	defer tc.close()
+
+	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(test.GetTestHttpNamespace(), true)
 
 	svcErr := errors.New("error listing services")
-
-	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
-	sdApi.EXPECT().ListNamespaces(context.TODO()).
-		Return([]*model.Namespace{test.GetTestHttpNamespace()}, nil)
-	sdApi.EXPECT().ListServices(context.TODO(), test.NsId).
+	tc.mockApi.EXPECT().ListServices(context.TODO(), test.NsId).
 		Return([]*model.Resource{}, svcErr)
 
-	sdc := getTestSdClient(t, sdApi)
-	svcs, err := sdc.ListServices(context.TODO(), test.NsName)
+	svcs, err := tc.client.ListServices(context.TODO(), test.NsName)
 	assert.Equal(t, svcErr, err)
 	assert.Empty(t, svcs)
 }
 
 func TestServiceDiscoveryClient_ListServices_InstanceError(t *testing.T) {
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
+	tc := getTestSdClient(t)
+	defer tc.close()
+
+	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(test.GetTestHttpNamespace(), true)
+
+	tc.mockApi.EXPECT().ListServices(context.TODO(), test.NsId).
+		Return([]*model.Resource{{Name: test.SvcName, Id: test.SvcId}}, nil)
+	tc.mockCache.EXPECT().CacheServiceId(test.NsName, test.SvcName, test.SvcId)
 
 	endptErr := errors.New("error listing endpoints")
-	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
-	sdApi.EXPECT().ListNamespaces(context.TODO()).
-		Return([]*model.Namespace{test.GetTestHttpNamespace()}, nil)
-	sdApi.EXPECT().ListServices(context.TODO(), test.NsId).
-		Return([]*model.Resource{{Name: test.SvcName, Id: test.SvcId}}, nil)
-	sdApi.EXPECT().ListInstances(context.TODO(), test.SvcId).
+	tc.mockCache.EXPECT().GetEndpoints(test.SvcId).Return(nil, false)
+	tc.mockApi.EXPECT().ListInstances(context.TODO(), test.SvcId).
 		Return([]types.InstanceSummary{}, endptErr)
 
-	sdc := getTestSdClient(t, sdApi)
-	svcs, err := sdc.ListServices(context.TODO(), test.NsName)
+	svcs, err := tc.client.ListServices(context.TODO(), test.NsName)
 	assert.Equal(t, endptErr, err)
 	assert.Empty(t, svcs)
 }
 
 func TestServiceDiscoveryClient_ListServices_NamespaceNotFound(t *testing.T) {
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
+	tc := getTestSdClient(t)
+	defer tc.close()
 
-	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
-	sdApi.EXPECT().ListNamespaces(context.TODO()).
+	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(nil, false)
+	tc.mockApi.EXPECT().ListNamespaces(context.TODO()).
 		Return([]*model.Namespace{}, nil)
+	tc.mockCache.EXPECT().CacheNilNamespace(test.NsName)
 
-	sdc := getTestSdClient(t, sdApi)
-	svcs, err := sdc.ListServices(context.TODO(), test.NsName)
+	svcs, err := tc.client.ListServices(context.TODO(), test.NsName)
 	assert.Empty(t, svcs)
 	assert.Nil(t, err, "No error for namespace not found")
-
-	cachedNs, found := sdc.namespaceCache.Get(test.NsName)
-	assert.True(t, found)
-	assert.Nil(t, cachedNs, "Namespace not found in the cache")
 }
 
 func TestServiceDiscoveryClient_CreateService_HappyCase(t *testing.T) {
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
+	tc := getTestSdClient(t)
+	defer tc.close()
 
-	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
-	sdApi.EXPECT().ListNamespaces(context.TODO()).
-		Return([]*model.Namespace{test.GetTestHttpNamespace()}, nil)
-	sdApi.EXPECT().CreateService(context.TODO(), *test.GetTestHttpNamespace(), test.SvcName).
+	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(test.GetTestHttpNamespace(), true)
+
+	tc.mockApi.EXPECT().CreateService(context.TODO(), *test.GetTestHttpNamespace(), test.SvcName).
 		Return(test.SvcId, nil)
+	tc.mockCache.EXPECT().CacheServiceId(test.NsName, test.SvcName, test.SvcId)
 
-	sdc := getTestSdClient(t, sdApi)
-	err := sdc.CreateService(context.TODO(), test.NsName, test.SvcName)
+	err := tc.client.CreateService(context.TODO(), test.NsName, test.SvcName)
 	assert.Nil(t, err, "No error for happy case")
-
-	cachedNs, _ := sdc.namespaceCache.Get(test.NsName)
-	assert.Equal(t, *test.GetTestHttpNamespace(), cachedNs, "Happy case caches namespace")
-	cachedSvc, _ := sdc.serviceIdCache.Get(fmt.Sprintf("%s/%s", test.NsName, test.SvcName))
-	assert.Equal(t, test.SvcId, cachedSvc, "Happy case caches service ID")
 }
 
 func TestServiceDiscoveryClient_CreateService_HappyCaseForDNSNamespace(t *testing.T) {
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
+	tc := getTestSdClient(t)
+	defer tc.close()
 
-	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
-	sdApi.EXPECT().ListNamespaces(context.TODO()).
-		Return([]*model.Namespace{test.GetTestDnsNamespace()}, nil)
-	sdApi.EXPECT().CreateService(context.TODO(), *test.GetTestDnsNamespace(), test.SvcName).
+	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(test.GetTestDnsNamespace(), true)
+
+	tc.mockApi.EXPECT().CreateService(context.TODO(), *test.GetTestDnsNamespace(), test.SvcName).
 		Return(test.SvcId, nil)
+	tc.mockCache.EXPECT().CacheServiceId(test.NsName, test.SvcName, test.SvcId)
 
-	sdc := getTestSdClient(t, sdApi)
-	err := sdc.CreateService(context.TODO(), test.NsName, test.SvcName)
-	assert.Nil(t, err, "No error for happy case")
-
-	cachedNs, _ := sdc.namespaceCache.Get(test.NsName)
-	assert.Equal(t, *test.GetTestDnsNamespace(), cachedNs, "Happy case caches namespace")
-	cachedSvc, _ := sdc.serviceIdCache.Get(fmt.Sprintf("%s/%s", test.NsName, test.SvcName))
-	assert.Equal(t, test.SvcId, cachedSvc, "Happy case caches service ID")
-}
-
-func TestServiceDiscoveryClient_CreateService_HappyCaseCachedResults(t *testing.T) {
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
-
-	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
-	sdApi.EXPECT().CreateService(context.TODO(), *test.GetTestHttpNamespace(), test.SvcName).
-		Return(test.SvcId, nil)
-
-	sdc := getTestSdClient(t, sdApi)
-	sdc.namespaceCache.Add(test.NsName, *test.GetTestHttpNamespace(), time.Minute)
-
-	err := sdc.CreateService(context.TODO(), test.NsName, test.SvcName)
+	err := tc.client.CreateService(context.TODO(), test.NsName, test.SvcName)
 	assert.Nil(t, err, "No error for happy case")
 }
 
 func TestServiceDiscoveryClient_CreateService_NamespaceError(t *testing.T) {
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
+	tc := getTestSdClient(t)
+	defer tc.close()
 
 	nsErr := errors.New("error listing namespaces")
-	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
-	sdApi.EXPECT().ListNamespaces(context.TODO()).
+	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(nil, false)
+	tc.mockApi.EXPECT().ListNamespaces(context.TODO()).
 		Return([]*model.Namespace{}, nsErr)
 
-	sdc := getTestSdClient(t, sdApi)
-	err := sdc.CreateService(context.TODO(), test.NsName, test.SvcName)
+	err := tc.client.CreateService(context.TODO(), test.NsName, test.SvcName)
 	assert.Equal(t, nsErr, err)
 }
 
 func TestServiceDiscoveryClient_CreateService_CreateServiceError(t *testing.T) {
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
+	tc := getTestSdClient(t)
+	defer tc.close()
+
+	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(test.GetTestDnsNamespace(), true)
 
 	svcErr := errors.New("error creating service")
-	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
-	sdApi.EXPECT().ListNamespaces(context.TODO()).
-		Return([]*model.Namespace{test.GetTestHttpNamespace()}, nil)
-	sdApi.EXPECT().CreateService(context.TODO(), *test.GetTestHttpNamespace(), test.SvcName).
+	tc.mockApi.EXPECT().CreateService(context.TODO(), *test.GetTestDnsNamespace(), test.SvcName).
 		Return("", svcErr)
 
-	sdc := getTestSdClient(t, sdApi)
-	err := sdc.CreateService(context.TODO(), test.NsName, test.SvcName)
+	err := tc.client.CreateService(context.TODO(), test.NsName, test.SvcName)
 	assert.Equal(t, err, svcErr)
 }
 
 func TestServiceDiscoveryClient_CreateService_CreatesNamespace_HappyCase(t *testing.T) {
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
+	tc := getTestSdClient(t)
+	defer tc.close()
 
-	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
-	sdc := getTestSdClient(t, sdApi)
-
-	sdApi.EXPECT().ListNamespaces(context.TODO()).
+	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(nil, false)
+	tc.mockApi.EXPECT().ListNamespaces(context.TODO()).
 		Return([]*model.Namespace{}, nil)
-	sdApi.EXPECT().CreateHttpNamespace(context.TODO(), test.NsName).
+	tc.mockCache.EXPECT().CacheNilNamespace(test.NsName)
+
+	tc.mockApi.EXPECT().CreateHttpNamespace(context.TODO(), test.NsName).
 		Return(test.OpId1, nil)
-	sdApi.EXPECT().PollNamespaceOperation(context.TODO(), test.OpId1).
+	tc.mockApi.EXPECT().PollNamespaceOperation(context.TODO(), test.OpId1).
 		Return(test.NsId, nil)
-	sdApi.EXPECT().CreateService(context.TODO(), *test.GetTestHttpNamespace(), test.SvcName).
+	tc.mockCache.EXPECT().CacheNamespace(test.GetTestHttpNamespace())
+
+	tc.mockApi.EXPECT().CreateService(context.TODO(), *test.GetTestHttpNamespace(), test.SvcName).
 		Return(test.SvcId, nil)
+	tc.mockCache.EXPECT().CacheServiceId(test.NsName, test.SvcName, test.SvcId)
 
-	err := sdc.CreateService(context.TODO(), test.NsName, test.SvcName)
+	err := tc.client.CreateService(context.TODO(), test.NsName, test.SvcName)
 	assert.Nil(t, err, "No error for happy case")
-
-	cachedNs, _ := sdc.namespaceCache.Get(test.NsName)
-	assert.Equal(t, *test.GetTestHttpNamespace(), cachedNs, "Create namespace caches namespace ID")
 }
 
 func TestServiceDiscoveryClient_CreateService_CreatesNamespace_PollError(t *testing.T) {
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
+	tc := getTestSdClient(t)
+	defer tc.close()
+
+	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(nil, false)
+	tc.mockApi.EXPECT().ListNamespaces(context.TODO()).
+		Return([]*model.Namespace{}, nil)
+	tc.mockCache.EXPECT().CacheNilNamespace(test.NsName)
 
 	pollErr := errors.New("polling error")
-	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
-	sdApi.EXPECT().ListNamespaces(context.TODO()).
-		Return([]*model.Namespace{}, nil)
-	sdApi.EXPECT().CreateHttpNamespace(context.TODO(), test.NsName).
+	tc.mockApi.EXPECT().CreateHttpNamespace(context.TODO(), test.NsName).
 		Return(test.OpId1, nil)
-	sdApi.EXPECT().PollNamespaceOperation(context.TODO(), test.OpId1).
+	tc.mockApi.EXPECT().PollNamespaceOperation(context.TODO(), test.OpId1).
 		Return("", pollErr)
 
-	sdc := getTestSdClient(t, sdApi)
-	err := sdc.CreateService(context.TODO(), test.NsName, test.SvcName)
+	err := tc.client.CreateService(context.TODO(), test.NsName, test.SvcName)
 	assert.Equal(t, pollErr, err)
 }
 
 func TestServiceDiscoveryClient_CreateService_CreatesNamespace_CreateNsError(t *testing.T) {
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
+	tc := getTestSdClient(t)
+	defer tc.close()
+
+	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(nil, false)
+	tc.mockApi.EXPECT().ListNamespaces(context.TODO()).
+		Return([]*model.Namespace{}, nil)
+	tc.mockCache.EXPECT().CacheNilNamespace(test.NsName)
 
 	nsErr := errors.New("create namespace error")
-	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
-	sdApi.EXPECT().ListNamespaces(context.TODO()).
-		Return([]*model.Namespace{}, nil)
-	sdApi.EXPECT().CreateHttpNamespace(context.TODO(), test.NsName).
+	tc.mockApi.EXPECT().CreateHttpNamespace(context.TODO(), test.NsName).
 		Return("", nsErr)
 
-	sdc := getTestSdClient(t, sdApi)
-	err := sdc.CreateService(context.TODO(), test.NsName, test.SvcName)
+	err := tc.client.CreateService(context.TODO(), test.NsName, test.SvcName)
 	assert.Equal(t, nsErr, err)
 }
 
 func TestServiceDiscoveryClient_GetService_HappyCase(t *testing.T) {
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
+	tc := getTestSdClient(t)
+	defer tc.close()
 
-	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
-	sdApi.EXPECT().ListNamespaces(context.TODO()).Return([]*model.Namespace{{Id: test.NsId, Name: test.NsName}}, nil)
-	sdApi.EXPECT().ListServices(context.TODO(), test.NsId).
+	tc.mockCache.EXPECT().GetServiceId(test.NsName, test.SvcName)
+
+	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(nil, false)
+	tc.mockApi.EXPECT().ListNamespaces(context.TODO()).
+		Return([]*model.Namespace{test.GetTestHttpNamespace()}, nil)
+	tc.mockCache.EXPECT().CacheNamespace(test.GetTestHttpNamespace())
+
+	tc.mockApi.EXPECT().ListServices(context.TODO(), test.NsId).
 		Return([]*model.Resource{{Id: test.SvcId, Name: test.SvcName}}, nil)
-	sdApi.EXPECT().ListInstances(context.TODO(), test.SvcId).
+	tc.mockCache.EXPECT().CacheServiceId(test.NsName, test.SvcName, test.SvcId)
+
+	tc.mockCache.EXPECT().GetEndpoints(test.SvcId).Return([]*model.Endpoint{}, false)
+	tc.mockApi.EXPECT().ListInstances(context.TODO(), test.SvcId).
 		Return([]types.InstanceSummary{
 			{
 				Id: aws.String(test.EndptId1),
@@ -316,50 +293,48 @@ func TestServiceDiscoveryClient_GetService_HappyCase(t *testing.T) {
 				},
 			},
 		}, nil)
-	sdc := getTestSdClient(t, sdApi)
+	tc.mockCache.EXPECT().CacheEndpoints(test.SvcId,
+		[]*model.Endpoint{test.GetTestEndpoint(), test.GetTestEndpoint2()})
 
-	svc, err := sdc.GetService(context.TODO(), test.NsName, test.SvcName)
+	svc, err := tc.client.GetService(context.TODO(), test.NsName, test.SvcName)
 	assert.Nil(t, err)
 	assert.Equal(t, test.GetTestService(), svc)
 }
 
 func TestServiceDiscoveryClient_GetService_CachedValues(t *testing.T) {
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
+	tc := getTestSdClient(t)
+	defer tc.close()
 
-	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
-	sdc := getTestSdClient(t, sdApi)
-	sdc.namespaceCache.Add(test.NsName, *test.GetTestHttpNamespace(), time.Minute)
-	sdc.serviceIdCache.Add(fmt.Sprintf("%s/%s", test.NsName, test.SvcName), test.SvcId, time.Minute)
-	sdc.endpointCache.Add(test.SvcId, []*model.Endpoint{test.GetTestEndpoint(), test.GetTestEndpoint2()}, time.Minute)
+	tc.mockCache.EXPECT().GetServiceId(test.NsName, test.SvcName).Return(test.SvcId, true)
+	tc.mockCache.EXPECT().GetEndpoints(test.SvcId).
+		Return([]*model.Endpoint{test.GetTestEndpoint(), test.GetTestEndpoint2()}, true)
 
-	svc, err := sdc.GetService(context.TODO(), test.NsName, test.SvcName)
+	svc, err := tc.client.GetService(context.TODO(), test.NsName, test.SvcName)
 	assert.Nil(t, err)
 	assert.Equal(t, test.GetTestService(), svc)
 }
 
 func TestServiceDiscoveryClient_RegisterEndpoints(t *testing.T) {
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
+	tc := getTestSdClient(t)
+	defer tc.close()
 
-	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
-	sdc := getTestSdClient(t, sdApi)
-	sdc.serviceIdCache.Add(fmt.Sprintf("%s/%s", test.NsName, test.SvcName), test.SvcId, time.Minute)
-	sdc.endpointCache.Add(test.SvcId, model.Endpoint{}, time.Minute)
+	tc.mockCache.EXPECT().GetServiceId(test.NsName, test.SvcName).Return(test.SvcId, true)
 
 	attrs1 := map[string]string{"AWS_INSTANCE_IPV4": test.EndptIp1, "AWS_INSTANCE_PORT": test.EndptPortStr1}
 	attrs2 := map[string]string{"AWS_INSTANCE_IPV4": test.EndptIp2, "AWS_INSTANCE_PORT": test.EndptPortStr2}
 
-	sdApi.EXPECT().RegisterInstance(context.TODO(), test.SvcId, test.EndptId1, attrs1).
+	tc.mockApi.EXPECT().RegisterInstance(context.TODO(), test.SvcId, test.EndptId1, attrs1).
 		Return(test.OpId1, nil)
-	sdApi.EXPECT().RegisterInstance(context.TODO(), test.SvcId, test.EndptId2, attrs2).
+	tc.mockApi.EXPECT().RegisterInstance(context.TODO(), test.SvcId, test.EndptId2, attrs2).
 		Return(test.OpId2, nil)
-	sdApi.EXPECT().ListOperations(context.TODO(), gomock.Any()).
+	tc.mockApi.EXPECT().ListOperations(context.TODO(), gomock.Any()).
 		Return(map[string]types.OperationStatus{
 			test.OpId1: types.OperationStatusSuccess,
 			test.OpId2: types.OperationStatusSuccess}, nil)
 
-	err := sdc.RegisterEndpoints(context.TODO(), test.NsName, test.SvcName,
+	tc.mockCache.EXPECT().EvictEndpoints(test.SvcId)
+
+	err := tc.client.RegisterEndpoints(context.TODO(), test.NsName, test.SvcName,
 		[]*model.Endpoint{
 			{
 				Id:   test.EndptId1,
@@ -374,78 +349,41 @@ func TestServiceDiscoveryClient_RegisterEndpoints(t *testing.T) {
 		})
 
 	assert.Nil(t, err)
-	_, entryCached := sdc.endpointCache.Get(test.SvcId)
-	assert.False(t, entryCached, "Cache entry evicted after register")
 }
 
 func TestServiceDiscoveryClient_DeleteEndpoints(t *testing.T) {
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
+	tc := getTestSdClient(t)
+	defer tc.close()
 
-	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
+	tc.mockCache.EXPECT().GetServiceId(test.NsName, test.SvcName).Return(test.SvcId, true)
 
-	sdc := getTestSdClient(t, sdApi)
-	sdc.serviceIdCache.Add(fmt.Sprintf("%s/%s", test.NsName, test.SvcName), test.SvcId, time.Minute)
-	sdc.endpointCache.Add(test.SvcId, model.Endpoint{}, time.Minute)
-
-	sdApi.EXPECT().DeregisterInstance(context.TODO(), test.SvcId, test.EndptId1).Return(test.OpId1, nil)
-	sdApi.EXPECT().DeregisterInstance(context.TODO(), test.SvcId, test.EndptId2).Return(test.OpId2, nil)
-	sdApi.EXPECT().ListOperations(context.TODO(), gomock.Any()).
+	tc.mockApi.EXPECT().DeregisterInstance(context.TODO(), test.SvcId, test.EndptId1).Return(test.OpId1, nil)
+	tc.mockApi.EXPECT().DeregisterInstance(context.TODO(), test.SvcId, test.EndptId2).Return(test.OpId2, nil)
+	tc.mockApi.EXPECT().ListOperations(context.TODO(), gomock.Any()).
 		Return(map[string]types.OperationStatus{
 			test.OpId1: types.OperationStatusSuccess,
 			test.OpId2: types.OperationStatusSuccess}, nil)
 
-	err := sdc.DeleteEndpoints(context.TODO(), test.NsName, test.SvcName,
+	tc.mockCache.EXPECT().EvictEndpoints(test.SvcId)
+
+	err := tc.client.DeleteEndpoints(context.TODO(), test.NsName, test.SvcName,
 		[]*model.Endpoint{{Id: test.EndptId1}, {Id: test.EndptId2}})
 
 	assert.Nil(t, err)
-	_, entryCached := sdc.endpointCache.Get(test.SvcId)
-	assert.False(t, entryCached, "Cache entry evicted after de-register")
 }
 
-func TestServiceDiscoveryClient_getNamespace_HappyCase(t *testing.T) {
+func getTestSdClient(t *testing.T) *testSdClient {
 	mockController := gomock.NewController(t)
-	defer mockController.Finish()
-
-	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
-
-	sdc := getTestSdClient(t, sdApi)
-	sdc.namespaceCache.Add(test.NsName, *test.GetTestHttpNamespace(), time.Minute)
-
-	namespace, _ := sdc.getNamespace(context.TODO(), test.NsName)
-	assert.Equal(t, test.GetTestHttpNamespace(), namespace, "Namespace found in the cache")
-}
-
-func TestServiceDiscoveryClient_getNamespace_GetEmptyNamespace(t *testing.T) {
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
-
-	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
-
-	sdc := getTestSdClient(t, sdApi)
-	sdc.namespaceCache.Add(test.NsName, nil, time.Minute)
-
-	namespace, err := sdc.getNamespace(context.TODO(), test.NsName)
-	assert.Nil(t, namespace, "Namespace not found in the cache")
-	assert.Nil(t, err, "No errors with empty namespace")
-}
-
-func TestServiceDiscoveryClient_getCachedNamespace_ErrorCasting(t *testing.T) {
-	sdc := getTestSdClient(t, nil)
-	sdc.namespaceCache.Add(test.NsName, struct{ dummy string }{"dummy"}, time.Minute)
-
-	namespace, exists, err := sdc.getCachedNamespace(test.NsName)
-	assert.True(t, exists, "Cache exists")
-	assert.Nil(t, namespace, "No corresponding cached value found")
-	assert.Equal(t, fmt.Sprintf("failed to cast the cached value for the namespace %s", test.NsName), fmt.Sprint(err), "Got the error for improper casting")
-}
-
-func getTestSdClient(t *testing.T, sdApi ServiceDiscoveryApi) serviceDiscoveryClient {
-	return serviceDiscoveryClient{
-		log:            testing2.TestLogger{T: t},
-		sdApi:          sdApi,
-		namespaceCache: cache.NewLRUExpireCache(1024),
-		serviceIdCache: cache.NewLRUExpireCache(1024),
-		endpointCache:  cache.NewLRUExpireCache(1024),
+	mockCache := cloudmap.NewMockServiceDiscoveryClientCache(mockController)
+	mockApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
+	return &testSdClient{
+		client: &serviceDiscoveryClient{
+			log:   testing2.TestLogger{T: t},
+			sdApi: mockApi,
+			cache: mockCache,
+		},
+		mockApi:   *mockApi,
+		mockCache: *mockCache,
+		close:     func() { mockController.Finish() },
 	}
 }


### PR DESCRIPTION
*Issue #, if available:*
#66

*Description of changes:*
Decouples the cache config and implementation from the Cloud Map client, and protects all interactions behind an interface. This allows us to construct clients with custom configs, for example in test scenarios. We will eventually expose this as setup configuration to the controller.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
