### PR TITLE
Extend integration test to support service import

### DIFF
--- a/integration/scripts/ensure-jq.sh
+++ b/integration/scripts/ensure-jq.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Ensure jq is available to parse json output. Installs jq on debian/ubuntu
+
+if ! which -s jq ; then
+  echo "jq not found, attempting to install"
+  if ! sudo apt-get install -y jq ; then
+    echo "failed to install jq, ensure it is available before running tests"
+    exit 1
+  fi
+fi
+
+exit 0

--- a/integration/scripts/run-tests.sh
+++ b/integration/scripts/run-tests.sh
@@ -2,20 +2,29 @@
 
 # Runs the AWS Cloud Map MCS Controller for K8s as a background process and tests services have been exported
 
-set -eo pipefail
-
 source ./integration/scripts/common.sh
 
 $KUBECTL_BIN apply -f "$CONFIGS/e2e-deployment.yaml"
 $KUBECTL_BIN apply -f "$CONFIGS/e2e-service.yaml"
 $KUBECTL_BIN apply -f "$CONFIGS/e2e-export.yaml"
 
-endpts=$(./integration/scripts/poll-endpoints.sh "$EXPECTED_ENDPOINT_COUNT")
+if ! endpts=$(./integration/scripts/poll-endpoints.sh "$EXPECTED_ENDPOINT_COUNT") ; then
+  exit $?
+fi
 
 mkdir -p "$LOGS"
 ./bin/manager &> "$LOGS/ctl.log" &
 CTL_PID=$!
+echo "controller PID:$CTL_PID"
 
 go run $SCENARIOS/runner/main.go $NAMESPACE $SERVICE $ENDPT_PORT "$endpts"
+exit_code=$?
 
+if [ "$exit_code" -eq 0 ] ; then
+  ./integration/scripts/test-import.sh "$endpts"
+  exit_code=$?
+fi
+
+echo "killing controller PID:$CTL_PID"
 kill $CTL_PID
+exit $exit_code

--- a/integration/scripts/setup-kind.sh
+++ b/integration/scripts/setup-kind.sh
@@ -7,6 +7,8 @@ set -e
 
 source ./integration/scripts/common.sh
 
+./integration/scripts/ensure-jq.sh
+
 $KIND_BIN create cluster --name "$KIND_SHORT" --image "$IMAGE"
 $KUBECTL_BIN config use-context "$CLUSTER"
 $KUBECTL_BIN create namespace "$NAMESPACE"

--- a/integration/scripts/test-import.sh
+++ b/integration/scripts/test-import.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Test service imports were created during e2e test
+
+set -e
+
+source ./integration/scripts/common.sh
+
+if [ "$#" -ne 1 ]; then
+    echo "test script expects endpoint IP list as single argument"
+    exit 1
+fi
+
+endpts=$1
+echo "checking service imports..."
+
+imports=$($KUBECTL_BIN get endpointslices -o json --namespace $NAMESPACE | \
+  jq '.items[] | select(.metadata.ownerReferences[].name | startswith("imported")) | .endpoints[].addresses[0]')
+import_count=$(echo "$imports" | wc -l | xargs)
+
+if ((import_count != EXPECTED_ENDPOINT_COUNT)) ; then
+  echo "expected $EXPECTED_ENDPOINT_COUNT imports but found $import_count"
+  exit 1
+fi
+
+echo "$imports" | tr -d '"' | while read -r import; do
+  echo "checking import: $import"
+  if ! echo "$endpts" | grep -q "$import" ; then
+    echo "exported endpoint not found: $import"
+    exit 1
+  fi
+done
+
+if [ $? -ne 0 ]; then
+    exit $?
+fi
+
+echo "matched all imports to exported endpoints"
+exit 0


### PR DESCRIPTION
*Issue #, if available:*
#45

*Description of changes:*
Add script to check if endpoint slices have been imported during integration test.
Switch from grepping kubectl import to favour parsing json with `jq`. Will attempt to install if not present, only works for debian-like environment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
