### PR TITLE
Reformat instance id to the format {protocol}://{ip}:{port}

### DIFF
--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/servicediscovery/types"
 	"reflect"
 	"strconv"
+	"strings"
 )
 
 // Resource encapsulates a ID/name pair.
@@ -188,7 +189,7 @@ func (e *Endpoint) String() string {
 
 // EndpointIdFromIPAddressAndPort converts an IP address to human-readable identifier.
 func EndpointIdFromIPAddressAndPort(address string, port Port) string {
-	return fmt.Sprintf("%s:%s:%d", port.Protocol, address, port.Port)
+	return fmt.Sprintf("%s://%s:%d", strings.ToLower(port.Protocol), address, port.Port)
 }
 
 func ConvertNamespaceType(nsType types.NamespaceType) (namespaceType NamespaceType) {

--- a/pkg/model/types_test.go
+++ b/pkg/model/types_test.go
@@ -182,7 +182,7 @@ func TestEndpointIdFromIPAddressAndPort(t *testing.T) {
 				Port:     80,
 				Protocol: "TCP",
 			},
-			want: "TCP:192.168.0.1:80",
+			want: "tcp://192.168.0.1:80",
 		},
 	}
 	for _, tt := range tests {

--- a/test/test-constants.go
+++ b/test/test-constants.go
@@ -9,8 +9,8 @@ const (
 	NsId            = "ns-id"
 	SvcName         = "svc-name"
 	SvcId           = "svc-id"
-	EndptId1        = "TCP:192.168.0.1:1"
-	EndptId2        = "TCP:192.168.0.2:2"
+	EndptId1        = "tcp://192.168.0.1:1"
+	EndptId2        = "tcp://192.168.0.2:2"
 	EndptIp1        = "192.168.0.1"
 	EndptIp2        = "192.168.0.2"
 	Port1           = 1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Reformat instance id to the format {protocol}://{ip}:{port}. Example `tcp://192.0.0.1:80`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
