### PR TITLE
Add the support for kubectl version <= 1.18

### DIFF
--- a/config/controller_install_latest/kustomization.yaml
+++ b/config/controller_install_latest/kustomization.yaml
@@ -1,4 +1,4 @@
-resources:
+bases:
 - ../default
 
 images:

--- a/config/controller_install_release/kustomization.yaml
+++ b/config/controller_install_release/kustomization.yaml
@@ -1,4 +1,4 @@
-resources:
+bases:
 - ../default
 
 images:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,7 +12,7 @@ namePrefix: cloud-map-mcs-
 #commonLabels:
 #  someName: someValue
 
-resources:
+bases:
 - ../crd
 - ../rbac
 - ../manager


### PR DESCRIPTION
*Issue #, if available:* Fixes https://github.com/aws/aws-cloud-map-mcs-controller-for-k8s/issues/80

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
