### PR TITLE
Change exported endpoint id delimiters, add ld flags to go run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ build: manifests generate generate-mocks fmt vet ## Build manager binary.
 	go build -ldflags="-s -w -X ${PKG}.GitVersion=${GIT_TAG} -X ${PKG}.GitCommit=${GIT_COMMIT}" -o bin/manager main.go
 
 run: manifests generate generate-mocks fmt vet ## Run a controller from your host.
-	go run ./main.go
+	go run -ldflags="-s -w -X ${PKG}.GitVersion=${GIT_TAG} -X ${PKG}.GitCommit=${GIT_COMMIT}" ./main.go
 
 docker-build: test ## Build docker image with the manager.
 	docker build $(ARGS) -t ${IMG} .

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -189,7 +189,9 @@ func (e *Endpoint) String() string {
 
 // EndpointIdFromIPAddressAndPort converts an IP address to human-readable identifier.
 func EndpointIdFromIPAddressAndPort(address string, port Port) string {
-	return fmt.Sprintf("%s://%s:%d", strings.ToLower(port.Protocol), address, port.Port)
+	address = strings.Replace(address, ".", "_", -1)
+	address = strings.Replace(address, ":", "_", -1)
+	return fmt.Sprintf("%s-%s-%d", strings.ToLower(port.Protocol), address, port.Port)
 }
 
 func ConvertNamespaceType(nsType types.NamespaceType) (namespaceType NamespaceType) {

--- a/pkg/model/types_test.go
+++ b/pkg/model/types_test.go
@@ -176,13 +176,13 @@ func TestEndpointIdFromIPAddressAndPort(t *testing.T) {
 	}{
 		{
 			name:    "happy case",
-			address: "192.168.0.1",
+			address: ip,
 			port: Port{
 				Name:     "http",
 				Port:     80,
 				Protocol: "TCP",
 			},
-			want: "tcp://192.168.0.1:80",
+			want: "tcp-192_168_0_1-80",
 		},
 	}
 	for _, tt := range tests {

--- a/test/test-constants.go
+++ b/test/test-constants.go
@@ -9,8 +9,8 @@ const (
 	NsId            = "ns-id"
 	SvcName         = "svc-name"
 	SvcId           = "svc-id"
-	EndptId1        = "tcp://192.168.0.1:1"
-	EndptId2        = "tcp://192.168.0.2:2"
+	EndptId1        = "tcp-192_168_0_1-1"
+	EndptId2        = "tcp-192_168_0_2-2"
 	EndptIp1        = "192.168.0.1"
 	EndptIp2        = "192.168.0.2"
 	Port1           = 1


### PR DESCRIPTION
*Issue #, if available:*
#84  
*Description of changes:*
Change endpoint ID delimiters from `.` and `:`  back to `_` to avoid R53 conflicts in DNS enabled namespaces. Separate protocol and port with `-`.
Add flags to `go run` to reflect running compiled executable behaviour.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
