### PR TITLE
Improve Logging

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -24,3 +24,5 @@ ignore:
   - "config/**/*"
   - "pkg/api/**/*"
   - "mocks/**/*"
+  - "integration/scenarios/**/*"
+  - "pkg/common/logger.go"

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ build: manifests generate generate-mocks fmt vet ## Build manager binary.
 	go build -ldflags="-s -w -X ${PKG}.GitVersion=${GIT_TAG} -X ${PKG}.GitCommit=${GIT_COMMIT}" -o bin/manager main.go
 
 run: manifests generate generate-mocks fmt vet ## Run a controller from your host.
-	go run -ldflags="-s -w -X ${PKG}.GitVersion=${GIT_TAG} -X ${PKG}.GitCommit=${GIT_COMMIT}" ./main.go
+	go run -ldflags="-s -w -X ${PKG}.GitVersion=${GIT_TAG} -X ${PKG}.GitCommit=${GIT_COMMIT}" ./main.go --zap-devel=true
 
 docker-build: test ## Build docker image with the manager.
 	docker build --no-cache -t ${IMG} .

--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ func main() {
 	serviceDiscoveryClient := cloudmap.NewDefaultServiceDiscoveryClient(&awsCfg)
 	if err = (&controllers.ServiceExportReconciler{
 		Client:   mgr.GetClient(),
-		Log:      common.NewLogger(ctrl.Log.WithName("controllers").WithName("ServiceExport")),
+		Log:      common.NewLogger("controllers", "ServiceExport"),
 		Scheme:   mgr.GetScheme(),
 		CloudMap: serviceDiscoveryClient,
 	}).SetupWithManager(mgr); err != nil {
@@ -113,7 +113,7 @@ func main() {
 	cloudMapReconciler := &controllers.CloudMapReconciler{
 		Client:   mgr.GetClient(),
 		Cloudmap: serviceDiscoveryClient,
-		Log:      common.NewLogger(ctrl.Log.WithName("controllers").WithName("Cloudmap")),
+		Log:      common.NewLogger("controllers", "Cloudmap"),
 	}
 
 	if err = mgr.Add(cloudMapReconciler); err != nil {

--- a/pkg/cloudmap/api.go
+++ b/pkg/cloudmap/api.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/common"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	sd "github.com/aws/aws-sdk-go-v2/service/servicediscovery"
 	"github.com/aws/aws-sdk-go-v2/service/servicediscovery/types"
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/util/wait"
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 const (
@@ -52,14 +51,14 @@ type ServiceDiscoveryApi interface {
 }
 
 type serviceDiscoveryApi struct {
-	log       logr.Logger
+	log       common.Logger
 	awsFacade AwsFacade
 }
 
 // NewServiceDiscoveryApiFromConfig creates a new AWS Cloud Map API connection manager from an AWS client config.
 func NewServiceDiscoveryApiFromConfig(cfg *aws.Config) ServiceDiscoveryApi {
 	return &serviceDiscoveryApi{
-		log:       ctrl.Log.WithName("cloudmap"),
+		log:       common.NewLogger("cloudmap"),
 		awsFacade: NewAwsFacadeFromConfig(cfg),
 	}
 }

--- a/pkg/cloudmap/api_test.go
+++ b/pkg/cloudmap/api_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/mocks/pkg/cloudmap"
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/common"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/test"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -319,7 +320,7 @@ func TestServiceDiscoveryApi_PollNamespaceOperation_HappyCase(t *testing.T) {
 
 func getServiceDiscoveryApi(t *testing.T, awsFacade *cloudmap.MockAwsFacade) ServiceDiscoveryApi {
 	return &serviceDiscoveryApi{
-		log:       testingLogger.TestLogger{T: t},
+		log:       common.NewLoggerWithLogr(testingLogger.TestLogger{T: t}),
 		awsFacade: awsFacade,
 	}
 }

--- a/pkg/cloudmap/cache.go
+++ b/pkg/cloudmap/cache.go
@@ -3,10 +3,9 @@ package cloudmap
 import (
 	"errors"
 	"fmt"
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/common"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/util/cache"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"time"
 )
 
@@ -33,7 +32,7 @@ type ServiceDiscoveryClientCache interface {
 }
 
 type sdCache struct {
-	log    logr.Logger
+	log    common.Logger
 	cache  *cache.LRUExpireCache
 	config *SdCacheConfig
 }
@@ -46,7 +45,7 @@ type SdCacheConfig struct {
 
 func NewServiceDiscoveryClientCache(cacheConfig *SdCacheConfig) ServiceDiscoveryClientCache {
 	return &sdCache{
-		log:    ctrl.Log.WithName("cloudmap"),
+		log:    common.NewLogger("cloudmap"),
 		cache:  cache.NewLRUExpireCache(defaultCacheSize),
 		config: cacheConfig,
 	}

--- a/pkg/cloudmap/client.go
+++ b/pkg/cloudmap/client.go
@@ -3,9 +3,9 @@ package cloudmap
 import (
 	"context"
 	"fmt"
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/common"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -29,7 +29,7 @@ type ServiceDiscoveryClient interface {
 }
 
 type serviceDiscoveryClient struct {
-	log   logr.Logger
+	log   common.Logger
 	sdApi ServiceDiscoveryApi
 	cache ServiceDiscoveryClientCache
 }
@@ -38,7 +38,7 @@ type serviceDiscoveryClient struct {
 // from a given AWS client config.
 func NewDefaultServiceDiscoveryClient(cfg *aws.Config) ServiceDiscoveryClient {
 	return &serviceDiscoveryClient{
-		log:   ctrl.Log.WithName("cloudmap"),
+		log:   common.NewLogger(ctrl.Log.WithName("cloudmap")),
 		sdApi: NewServiceDiscoveryApiFromConfig(cfg),
 		cache: NewDefaultServiceDiscoveryClientCache(),
 	}
@@ -46,7 +46,7 @@ func NewDefaultServiceDiscoveryClient(cfg *aws.Config) ServiceDiscoveryClient {
 
 func NewServiceDiscoveryClientWithCustomCache(cfg *aws.Config, cacheConfig *SdCacheConfig) ServiceDiscoveryClient {
 	return &serviceDiscoveryClient{
-		log:   ctrl.Log.WithName("cloudmap"),
+		log:   common.NewLogger(ctrl.Log.WithName("cloudmap")),
 		sdApi: NewServiceDiscoveryApiFromConfig(cfg),
 		cache: NewServiceDiscoveryClientCache(cacheConfig),
 	}

--- a/pkg/cloudmap/client.go
+++ b/pkg/cloudmap/client.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/common"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
 	"github.com/aws/aws-sdk-go-v2/aws"
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 // ServiceDiscoveryClient provides the service endpoint management functionality required by the AWS Cloud Map
@@ -38,7 +37,7 @@ type serviceDiscoveryClient struct {
 // from a given AWS client config.
 func NewDefaultServiceDiscoveryClient(cfg *aws.Config) ServiceDiscoveryClient {
 	return &serviceDiscoveryClient{
-		log:   common.NewLogger(ctrl.Log.WithName("cloudmap")),
+		log:   common.NewLogger("cloudmap"),
 		sdApi: NewServiceDiscoveryApiFromConfig(cfg),
 		cache: NewDefaultServiceDiscoveryClientCache(),
 	}
@@ -46,7 +45,7 @@ func NewDefaultServiceDiscoveryClient(cfg *aws.Config) ServiceDiscoveryClient {
 
 func NewServiceDiscoveryClientWithCustomCache(cfg *aws.Config, cacheConfig *SdCacheConfig) ServiceDiscoveryClient {
 	return &serviceDiscoveryClient{
-		log:   common.NewLogger(ctrl.Log.WithName("cloudmap")),
+		log:   common.NewLogger("cloudmap"),
 		sdApi: NewServiceDiscoveryApiFromConfig(cfg),
 		cache: NewServiceDiscoveryClientCache(cacheConfig),
 	}

--- a/pkg/cloudmap/client_test.go
+++ b/pkg/cloudmap/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/mocks/pkg/cloudmap"
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/common"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/test"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -410,7 +411,7 @@ func getTestSdClient(t *testing.T) *testSdClient {
 	mockApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
 	return &testSdClient{
 		client: &serviceDiscoveryClient{
-			log:   testing2.TestLogger{T: t},
+			log:   common.NewLogger(testing2.TestLogger{T: t}),
 			sdApi: mockApi,
 			cache: mockCache,
 		},

--- a/pkg/cloudmap/client_test.go
+++ b/pkg/cloudmap/client_test.go
@@ -411,7 +411,7 @@ func getTestSdClient(t *testing.T) *testSdClient {
 	mockApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
 	return &testSdClient{
 		client: &serviceDiscoveryClient{
-			log:   common.NewLogger(testing2.TestLogger{T: t}),
+			log:   common.NewLoggerWithLogr(testing2.TestLogger{T: t}),
 			sdApi: mockApi,
 			cache: mockCache,
 		},

--- a/pkg/cloudmap/operation_collector.go
+++ b/pkg/cloudmap/operation_collector.go
@@ -1,8 +1,7 @@
 package cloudmap
 
 import (
-	"github.com/go-logr/logr"
-	ctrl "sigs.k8s.io/controller-runtime"
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/common"
 	"sync"
 )
 
@@ -22,7 +21,7 @@ type OperationCollector interface {
 }
 
 type opCollector struct {
-	log              logr.Logger
+	log              common.Logger
 	opChan           chan opResult
 	wg               sync.WaitGroup
 	startTime        int64
@@ -36,7 +35,7 @@ type opResult struct {
 
 func NewOperationCollector() OperationCollector {
 	return &opCollector{
-		log:              ctrl.Log.WithName("cloudmap"),
+		log:              common.NewLogger("cloudmap"),
 		opChan:           make(chan opResult),
 		startTime:        Now(),
 		createOpsSuccess: true,

--- a/pkg/cloudmap/operation_poller.go
+++ b/pkg/cloudmap/operation_poller.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/servicediscovery/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"strconv"
 	"time"
 )
@@ -41,7 +40,7 @@ type operationPoller struct {
 
 func newOperationPoller(sdApi ServiceDiscoveryApi, svcId string, opIds []string, startTime int64) operationPoller {
 	return operationPoller{
-		log:     common.NewLogger(ctrl.Log.WithName("cloudmap")),
+		log:     common.NewLogger("cloudmap"),
 		sdApi:   sdApi,
 		timeout: defaultOperationPollTimeout,
 

--- a/pkg/cloudmap/operation_poller.go
+++ b/pkg/cloudmap/operation_poller.go
@@ -3,9 +3,9 @@ package cloudmap
 import (
 	"context"
 	"errors"
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/common"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/servicediscovery/types"
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"strconv"
@@ -29,7 +29,7 @@ type OperationPoller interface {
 }
 
 type operationPoller struct {
-	log     logr.Logger
+	log     common.Logger
 	sdApi   ServiceDiscoveryApi
 	timeout time.Duration
 
@@ -41,7 +41,7 @@ type operationPoller struct {
 
 func newOperationPoller(sdApi ServiceDiscoveryApi, svcId string, opIds []string, startTime int64) operationPoller {
 	return operationPoller{
-		log:     ctrl.Log.WithName("cloudmap"),
+		log:     common.NewLogger(ctrl.Log.WithName("cloudmap")),
 		sdApi:   sdApi,
 		timeout: defaultOperationPollTimeout,
 

--- a/pkg/cloudmap/operation_poller_test.go
+++ b/pkg/cloudmap/operation_poller_test.go
@@ -186,7 +186,7 @@ func TestOperationPoller_PollTimeout(t *testing.T) {
 	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
 
 	p := operationPoller{
-		log:     common.NewLogger(testing2.TestLogger{T: t}),
+		log:     common.NewLoggerWithLogr(testing2.TestLogger{T: t}),
 		sdApi:   sdApi,
 		timeout: 2 * time.Millisecond,
 		opIds:   []string{test.OpId1, test.OpId2},

--- a/pkg/cloudmap/operation_poller_test.go
+++ b/pkg/cloudmap/operation_poller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/mocks/pkg/cloudmap"
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/common"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/test"
 	"github.com/aws/aws-sdk-go-v2/service/servicediscovery/types"
 	testing2 "github.com/go-logr/logr/testing"
@@ -185,7 +186,7 @@ func TestOperationPoller_PollTimeout(t *testing.T) {
 	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
 
 	p := operationPoller{
-		log:     testing2.TestLogger{T: t},
+		log:     common.NewLogger(testing2.TestLogger{T: t}),
 		sdApi:   sdApi,
 		timeout: 2 * time.Millisecond,
 		opIds:   []string{test.OpId1, test.OpId2},

--- a/pkg/common/logger.go
+++ b/pkg/common/logger.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 type Logger interface {
@@ -14,7 +15,15 @@ type logger struct {
 	log logr.Logger
 }
 
-func NewLogger(l logr.Logger) Logger {
+func NewLogger(name string, names ...string) Logger {
+	l := ctrl.Log.WithName(name)
+	for _, n := range names {
+		l = l.WithName(n)
+	}
+	return logger{log: l}
+}
+
+func NewLoggerWithLogr(l logr.Logger) Logger {
 	return logger{log: l}
 }
 

--- a/pkg/common/logger.go
+++ b/pkg/common/logger.go
@@ -1,0 +1,35 @@
+package common
+
+import (
+	"github.com/go-logr/logr"
+)
+
+type Logger interface {
+	Info(msg string, keysAndValues ...interface{})
+	Debug(msg string, keysAndValues ...interface{})
+	Error(err error, msg string, keysAndValues ...interface{})
+}
+
+type logger struct {
+	log logr.Logger
+}
+
+func NewLogger(l logr.Logger) Logger {
+	return logger{log: l}
+}
+
+func (l logger) Info(msg string, keysAndValues ...interface{}) {
+	l.log.Info(msg, keysAndValues...)
+}
+
+func (l logger) Debug(msg string, keysAndValues ...interface{}) {
+	l.log.V(1).Info(msg, keysAndValues...)
+}
+
+func (l logger) Error(err error, msg string, keysAndValues ...interface{}) {
+	l.log.Error(err, msg, keysAndValues...)
+}
+
+func (l logger) WithValues(keysAndValues ...interface{}) Logger {
+	return logger{log: l.log.WithValues(keysAndValues...)}
+}

--- a/pkg/controllers/cloudmap_controller_test.go
+++ b/pkg/controllers/cloudmap_controller_test.go
@@ -85,6 +85,6 @@ func getReconciler(t *testing.T, mockSDClient *cloudmap.MockServiceDiscoveryClie
 	return &CloudMapReconciler{
 		Client:   client,
 		Cloudmap: mockSDClient,
-		Log:      common.NewLogger(testingLogger.TestLogger{T: t}),
+		Log:      common.NewLoggerWithLogr(testingLogger.TestLogger{T: t}),
 	}
 }

--- a/pkg/controllers/cloudmap_controller_test.go
+++ b/pkg/controllers/cloudmap_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/mocks/pkg/cloudmap"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/api/v1alpha1"
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/common"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/test"
 	testingLogger "github.com/go-logr/logr/testing"
@@ -84,6 +85,6 @@ func getReconciler(t *testing.T, mockSDClient *cloudmap.MockServiceDiscoveryClie
 	return &CloudMapReconciler{
 		Client:   client,
 		Cloudmap: mockSDClient,
-		Logger:   testingLogger.TestLogger{T: t},
+		Log:      common.NewLogger(testingLogger.TestLogger{T: t}),
 	}
 }

--- a/pkg/controllers/serviceexport_controller_test.go
+++ b/pkg/controllers/serviceexport_controller_test.go
@@ -165,7 +165,7 @@ func getServiceExportScheme() *runtime.Scheme {
 func getServiceExportReconciler(t *testing.T, mockClient *cloudmap.MockServiceDiscoveryClient, client client.Client) *ServiceExportReconciler {
 	return &ServiceExportReconciler{
 		Client:   client,
-		Log:      common.NewLogger(testing2.TestLogger{T: t}),
+		Log:      common.NewLoggerWithLogr(testing2.TestLogger{T: t}),
 		Scheme:   client.Scheme(),
 		CloudMap: mockClient,
 	}

--- a/pkg/controllers/serviceexport_controller_test.go
+++ b/pkg/controllers/serviceexport_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/mocks/pkg/cloudmap"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/api/v1alpha1"
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/common"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/test"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -164,7 +165,7 @@ func getServiceExportScheme() *runtime.Scheme {
 func getServiceExportReconciler(t *testing.T, mockClient *cloudmap.MockServiceDiscoveryClient, client client.Client) *ServiceExportReconciler {
 	return &ServiceExportReconciler{
 		Client:   client,
-		Log:      testing2.TestLogger{T: t},
+		Log:      common.NewLogger(testing2.TestLogger{T: t}),
 		Scheme:   client.Scheme(),
 		CloudMap: mockClient,
 	}


### PR DESCRIPTION
*Issue #, if available:* Fixes https://github.com/aws/aws-cloud-map-mcs-controller-for-k8s/issues/102

*Description of changes:* Reduce the noise in the logging by adding a wrapper around the logr.Logger to take the advantage of zapr logging levels. zapr provides development mode which sets to logLevel=Debug, and the production mode to logLevel=Info. By default, production mode is enabled, unless explicit argument to set the development mode. Reference: https://sdk.operatorframework.io/docs/building-operators/golang/references/logging/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
