### PR TITLE
Track v1 release for configure aws creds

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,7 +12,7 @@ jobs:
       id-token: write
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@master
+        uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-region: us-west-2
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The release for AWS configure credentials with [OIDC support](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v1.6.0) is out! Tracking v1 tag instead of master branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
