### PR TITLE
Improve import updates with slice change plans and port deltas

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -20,6 +20,12 @@ linters:
     - misspell
     - whitespace
 
+issues:
+  exclude-rules:
+    - path: _test\.go # disable some linters on test files
+      linters:
+        - dupl
+
 run:
   issues-exit-code: 1
   concurrency: 4

--- a/integration/scenarios/export_service.go
+++ b/integration/scenarios/export_service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/controllers"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -46,7 +47,7 @@ func NewExportServiceScenario(cfg *aws.Config, nsName string, svcName string, po
 	for _, ip := range strings.Split(ips, ",") {
 		endpointPort := model.Port{
 			Port:     int32(port),
-			Protocol: model.TCPProtocol,
+			Protocol: string(v1.ProtocolTCP),
 		}
 		endpts = append(endpts, &model.Endpoint{
 			Id: model.EndpointIdFromIPAddressAndPort(ip, endpointPort),
@@ -54,7 +55,7 @@ func NewExportServiceScenario(cfg *aws.Config, nsName string, svcName string, po
 			ServicePort: model.Port{
 				Port:       int32(servicePort),
 				TargetPort: portStr,
-				Protocol:   model.TCPProtocol,
+				Protocol:   string(v1.ProtocolTCP),
 			},
 			EndpointPort: endpointPort,
 			Attributes:   make(map[string]string),

--- a/pkg/controllers/cloudmap_controller.go
+++ b/pkg/controllers/cloudmap_controller.go
@@ -2,11 +2,7 @@ package controllers
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/base32"
 	"fmt"
-	"reflect"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/api/v1alpha1"
@@ -16,8 +12,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -25,14 +19,6 @@ import (
 const (
 	// TODO move to configuration
 	syncPeriod = 2 * time.Second
-
-	maxEndpointsPerSlice = 100
-
-	// DerivedServiceAnnotation annotates a ServiceImport with derived Service name
-	DerivedServiceAnnotation = "multicluster.k8s.aws/derived-service"
-
-	// LabelServiceImportName indicates the name of the multi-cluster service that an EndpointSlice belongs to.
-	LabelServiceImportName = "multicluster.kubernetes.io/service-name"
 )
 
 // CloudMapReconciler reconciles state of Cloud Map services with local ServiceImport objects
@@ -93,7 +79,7 @@ func (r *CloudMapReconciler) reconcileNamespace(ctx context.Context, namespaceNa
 	}
 
 	serviceImports := v1alpha1.ServiceImportList{}
-	if err := r.Client.List(ctx, &serviceImports, client.InNamespace(namespaceName)); err != nil {
+	if err = r.Client.List(ctx, &serviceImports, client.InNamespace(namespaceName)); err != nil {
 		r.Log.Error(err, "failed to reconcile namespace", "namespace", namespaceName)
 		return nil
 	}
@@ -109,7 +95,7 @@ func (r *CloudMapReconciler) reconcileNamespace(ctx context.Context, namespaceNa
 			continue
 		}
 
-		if err := r.reconcileService(ctx, svc); err != nil {
+		if err = r.reconcileService(ctx, svc); err != nil {
 			r.Log.Error(err, "error when syncing service", "namespace", svc.Namespace, "name", svc.Name)
 		}
 		delete(existingImportsMap, svc.Namespace+"/"+svc.Name)
@@ -117,7 +103,7 @@ func (r *CloudMapReconciler) reconcileNamespace(ctx context.Context, namespaceNa
 
 	// delete remaining imports that have not been matched
 	for _, i := range existingImportsMap {
-		if err := r.Client.Delete(ctx, &i); err != nil {
+		if err = r.Client.Delete(ctx, &i); err != nil {
 			r.Log.Error(err, "error deleting ServiceImport", "namespace", i.Namespace, "name", i.Name)
 			continue
 		}
@@ -130,6 +116,8 @@ func (r *CloudMapReconciler) reconcileNamespace(ctx context.Context, namespaceNa
 func (r *CloudMapReconciler) reconcileService(ctx context.Context, svc *model.Service) error {
 	r.Log.Info("syncing service", "namespace", svc.Namespace, "service", svc.Name)
 
+	importedSvcPorts := ExtractServicePorts(svc.Endpoints)
+
 	svcImport, err := r.getServiceImport(ctx, svc.Namespace, svc.Name)
 	if err != nil {
 		if !errors.IsNotFound(err) {
@@ -137,7 +125,7 @@ func (r *CloudMapReconciler) reconcileService(ctx context.Context, svc *model.Se
 		}
 
 		// create ServiceImport if it doesn't exist
-		if svcImport, err = r.createAndGetServiceImport(ctx, svc.Namespace, svc.Name); err != nil {
+		if svcImport, err = r.createAndGetServiceImport(ctx, svc.Namespace, svc.Name, importedSvcPorts); err != nil {
 			return err
 		}
 	}
@@ -149,22 +137,22 @@ func (r *CloudMapReconciler) reconcileService(ctx context.Context, svc *model.Se
 		}
 
 		// create derived Service if it doesn't exist
-		if derivedService, err = r.createAndGetDerivedService(ctx, svc, svcImport); err != nil {
+		if derivedService, err = r.createAndGetDerivedService(ctx, svcImport, importedSvcPorts); err != nil {
 			return err
 		}
 	}
 
-	// update ServiceImport to match IP and port of previously created service
-	if err = r.updateServiceImport(ctx, svcImport, derivedService); err != nil {
+	// update service import to match derived service cluster IP and imported ports if necessary
+	if err = r.updateServiceImport(ctx, svcImport, derivedService, importedSvcPorts); err != nil {
 		return err
 	}
 
-	err = r.updateEndpointSlices(ctx, svcImport, svc.Endpoints, derivedService)
-	if err != nil {
+	// update derived service ports to match imported ports if necessary
+	if err = r.updateDerivedService(ctx, derivedService, importedSvcPorts); err != nil {
 		return err
 	}
 
-	return nil
+	return r.updateEndpointSlices(ctx, svcImport, svc.Endpoints, derivedService)
 }
 
 func (r *CloudMapReconciler) getServiceImport(ctx context.Context, namespace string, name string) (*v1alpha1.ServiceImport, error) {
@@ -173,24 +161,12 @@ func (r *CloudMapReconciler) getServiceImport(ctx context.Context, namespace str
 	return existingServiceImport, err
 }
 
-func (r *CloudMapReconciler) createAndGetServiceImport(ctx context.Context, namespace string, name string) (*v1alpha1.ServiceImport, error) {
-	imp := &v1alpha1.ServiceImport{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:   namespace,
-			Name:        name,
-			Annotations: map[string]string{DerivedServiceAnnotation: DerivedName(namespace, name)},
-		},
-		Spec: v1alpha1.ServiceImportSpec{
-			IPs:   []string{},
-			Type:  v1alpha1.ClusterSetIP,
-			Ports: []v1alpha1.ServicePort{},
-		},
-	}
-
-	if err := r.Client.Create(ctx, imp); err != nil {
+func (r *CloudMapReconciler) createAndGetServiceImport(ctx context.Context, namespace string, name string, servicePorts []*model.Port) (*v1alpha1.ServiceImport, error) {
+	toCreate := CreateServiceImportStruct(namespace, name, servicePorts)
+	if err := r.Client.Create(ctx, toCreate); err != nil {
 		return nil, err
 	}
-	r.Log.Info("created ServiceImport", "namespace", imp.Namespace, "name", imp.Name)
+	r.Log.Info("created ServiceImport", "namespace", namespace, "name", name)
 
 	return r.getServiceImport(ctx, namespace, name)
 }
@@ -201,14 +177,14 @@ func (r *CloudMapReconciler) getDerivedService(ctx context.Context, namespace st
 	return existingService, err
 }
 
-func (r *CloudMapReconciler) createAndGetDerivedService(ctx context.Context, svc *model.Service, svcImport *v1alpha1.ServiceImport) (*v1.Service, error) {
-	toCreate := createDerivedServiceStruct(svc.Endpoints, svcImport)
+func (r *CloudMapReconciler) createAndGetDerivedService(ctx context.Context, svcImport *v1alpha1.ServiceImport, svcPorts []*model.Port) (*v1.Service, error) {
+	toCreate := CreateDerivedServiceStruct(svcImport, svcPorts)
 	if err := r.Client.Create(ctx, toCreate); err != nil {
 		return nil, err
 	}
 	r.Log.Info("created derived Service", "namespace", toCreate.Namespace, "name", toCreate.Name)
 
-	return r.getDerivedService(ctx, svc.Namespace, svcImport.Annotations[DerivedServiceAnnotation])
+	return r.getDerivedService(ctx, toCreate.Namespace, svcImport.Annotations[DerivedServiceAnnotation])
 }
 
 func (r *CloudMapReconciler) updateEndpointSlices(ctx context.Context, svcImport *v1alpha1.ServiceImport, desiredEndpoints []*model.Endpoint, svc *v1.Service) error {
@@ -218,90 +194,32 @@ func (r *CloudMapReconciler) updateEndpointSlices(ctx context.Context, svcImport
 		return err
 	}
 
-	desiredPorts := extractEndpointPorts(desiredEndpoints)
-	matchedEndpoints := make(map[string]*discovery.Endpoint)
-	endpointsToCreate := make([]discovery.Endpoint, 0)
+	plan := EndpointSlicePlan{
+		Current:           existingSlicesList.Items,
+		Desired:           desiredEndpoints,
+		Service:           svc,
+		ServiceImportName: svcImport.Name,
+	}
 
-	// populate map of existing endpoints in slices for lookup efficiency
-	existingEndpointMap := make(map[string]*discovery.Endpoint)
-	for _, existingSlice := range existingSlicesList.Items {
-		for _, existingEndpoint := range existingSlice.Endpoints {
-			ref := existingEndpoint
-			existingEndpointMap[ref.Addresses[0]] = &ref
+	changes := plan.CalculateChanges()
+
+	for _, sliceToUpdate := range changes.Update {
+		r.Log.Debug("updating EndpointSlice", "namespace", sliceToUpdate.Namespace, "name", sliceToUpdate.Name)
+		if err := r.Client.Update(ctx, sliceToUpdate); err != nil {
+			return fmt.Errorf("failed to update EndpointSlice: %w", err)
 		}
 	}
 
-	// check if all desired endpoints are in an endpoint slice already
-	for _, desiredEndpoint := range desiredEndpoints {
-		match, exists := existingEndpointMap[desiredEndpoint.IP]
-		if exists {
-			matchedEndpoints[desiredEndpoint.IP] = match
-		} else {
-			endpointsToCreate = append(endpointsToCreate, createEndpointForSlice(svc, desiredEndpoint.IP))
+	for _, sliceToDelete := range changes.Delete {
+		r.Log.Debug("deleting EndpointSlice", "namespace", sliceToDelete.Namespace, "name", sliceToDelete.Name)
+		if err := r.Client.Delete(ctx, sliceToDelete); err != nil {
+			return fmt.Errorf("failed to delete EndpointSlice: %w", err)
 		}
 	}
 
-	// check if all endpoints in slices match a desired endpoint,
-	for _, existingSlice := range existingSlicesList.Items {
-		updatedEndpointList := make([]discovery.Endpoint, 0)
-		for _, existingEndpoint := range existingSlice.Endpoints {
-			keep, found := matchedEndpoints[existingEndpoint.Addresses[0]]
-			if found {
-				updatedEndpointList = append(updatedEndpointList, *keep)
-			}
-		}
-
-		endpointSliceNeedsUpdate := len(existingSlice.Endpoints) != len(updatedEndpointList)
-
-		// fill endpoint slice with endpoints to create if necessary and there is sufficient room
-		for _, endpointToCreate := range endpointsToCreate {
-			if len(updatedEndpointList) >= maxEndpointsPerSlice {
-				break
-			}
-			endpointSliceNeedsUpdate = true
-			updatedEndpointList = append(updatedEndpointList, endpointToCreate)
-			endpointsToCreate = endpointsToCreate[1:]
-		}
-
-		sliceToUpdate := existingSlice
-		sliceToUpdate.Endpoints = updatedEndpointList
-
-		// delete empty endpoint slice
-		if len(updatedEndpointList) == 0 {
-			r.Log.Info("deleting EndpointSlice", "namespace", sliceToUpdate.Namespace, "name", sliceToUpdate.Name)
-			if err := r.Client.Delete(ctx, &sliceToUpdate); err != nil {
-				return fmt.Errorf("failed to delete EndpointSlice: %w", err)
-			}
-			continue
-		}
-
-		// needsUpdate = true if ports don't match
-		if !EndpointPortsAreEqualIgnoreOrder(desiredPorts, sliceToUpdate.Ports) {
-			sliceToUpdate.Ports = desiredPorts
-			endpointSliceNeedsUpdate = true
-		}
-
-		if endpointSliceNeedsUpdate {
-			r.Log.Info("updating EndpointSlice", "namespace", sliceToUpdate.Namespace, "name", sliceToUpdate.Name)
-			if err := r.Client.Update(ctx, &sliceToUpdate); err != nil {
-				return fmt.Errorf("failed to update EndpointSlice: %w", err)
-			}
-		}
-	}
-
-	slicesToCreate := make([]*discovery.EndpointSlice, 0)
-	for len(endpointsToCreate) > maxEndpointsPerSlice {
-		slicesToCreate = append(slicesToCreate, createEndpointSliceStruct(svcImport, svc, endpointsToCreate[0:maxEndpointsPerSlice], desiredPorts))
-		endpointsToCreate = endpointsToCreate[maxEndpointsPerSlice:]
-	}
-
-	if len(endpointsToCreate) != 0 {
-		slicesToCreate = append(slicesToCreate, createEndpointSliceStruct(svcImport, svc, endpointsToCreate, desiredPorts))
-	}
-
-	for _, newSlice := range slicesToCreate {
-		r.Log.Info("creating EndpointSlice", "namespace", newSlice.Namespace)
-		if err := r.Client.Create(ctx, newSlice); err != nil {
+	for _, sliceToCreate := range changes.Create {
+		r.Log.Debug("creating EndpointSlice", "namespace", sliceToCreate.Namespace)
+		if err := r.Client.Create(ctx, sliceToCreate); err != nil {
 			return fmt.Errorf("failed to create EndpointSlice: %w", err)
 		}
 	}
@@ -309,106 +227,41 @@ func (r *CloudMapReconciler) updateEndpointSlices(ctx context.Context, svcImport
 	return nil
 }
 
-// DerivedName computes the "placeholder" name for the imported service
-func DerivedName(namespace string, name string) string {
-	hash := sha256.New()
-	hash.Write([]byte(namespace + name))
-	return "imported-" + strings.ToLower(base32.HexEncoding.WithPadding(base32.NoPadding).EncodeToString(hash.Sum(nil)))[:10]
-}
-
-func createDerivedServiceStruct(endpoints []*model.Endpoint, svcImport *v1alpha1.ServiceImport) *v1.Service {
-	ownerRef := metav1.NewControllerRef(svcImport, schema.GroupVersionKind{
-		Version: svcImport.TypeMeta.APIVersion,
-		Kind:    svcImport.TypeMeta.Kind,
-	})
-
-	return &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:       svcImport.Namespace,
-			Name:            svcImport.Annotations[DerivedServiceAnnotation],
-			OwnerReferences: []metav1.OwnerReference{*ownerRef},
-		},
-		Spec: v1.ServiceSpec{
-			Type:  v1.ServiceTypeClusterIP,
-			Ports: extractServicePorts(endpoints),
-		},
-	}
-}
-
-func createEndpointForSlice(svc *v1.Service, ip string) discovery.Endpoint {
-	t := true
-
-	return discovery.Endpoint{
-		Addresses: []string{ip},
-		Conditions: discovery.EndpointConditions{
-			Ready: &t,
-		},
-		TargetRef: &v1.ObjectReference{
-			Kind:            "Service",
-			Namespace:       svc.Namespace,
-			Name:            svc.Name,
-			UID:             svc.ObjectMeta.UID,
-			ResourceVersion: svc.ObjectMeta.ResourceVersion,
-		},
-	}
-}
-
-func createEndpointSliceStruct(svcImport *v1alpha1.ServiceImport, svc *v1.Service, endpoints []discovery.Endpoint, ports []discovery.EndpointPort) *discovery.EndpointSlice {
-	return &discovery.EndpointSlice{
-		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
-				discovery.LabelServiceName: svc.Name,       // derived Service name
-				LabelServiceImportName:     svcImport.Name, // original ServiceImport name
-			},
-			GenerateName: svc.Name + "-",
-			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(svc, schema.GroupVersionKind{
-				Version: svc.TypeMeta.APIVersion,
-				Kind:    svc.TypeMeta.Kind,
-			})},
-			Namespace: svc.Namespace,
-		},
-		AddressType: discovery.AddressTypeIPv4,
-		Endpoints:   endpoints,
-		Ports:       ports,
-	}
-}
-
-func extractServicePorts(endpoints []*model.Endpoint) []v1.ServicePort {
-	uniquePorts := make(map[string]model.Port)
-	for _, ep := range endpoints {
-		uniquePorts[ep.ServicePort.GetID()] = ep.ServicePort
-	}
-
-	servicePorts := make([]v1.ServicePort, 0, len(uniquePorts))
-	for _, servicePort := range uniquePorts {
-		servicePorts = append(servicePorts, PortToServicePort(servicePort))
-	}
-
-	return servicePorts
-}
-
-func extractEndpointPorts(endpoints []*model.Endpoint) []discovery.EndpointPort {
-	uniquePorts := make(map[string]model.Port)
-	for _, ep := range endpoints {
-		uniquePorts[ep.EndpointPort.GetID()] = ep.EndpointPort
-	}
-
-	endpointPorts := make([]discovery.EndpointPort, 0, len(uniquePorts))
-	for _, endpointPort := range uniquePorts {
-		endpointPorts = append(endpointPorts, PortToEndpointPort(endpointPort))
-	}
-
-	return endpointPorts
-}
-
-func (r *CloudMapReconciler) updateServiceImport(ctx context.Context, svcImport *v1alpha1.ServiceImport, svc *v1.Service) error {
-	if len(svcImport.Spec.IPs) != 1 || svcImport.Spec.IPs[0] != svc.Spec.ClusterIP || !portsEqual(svcImport, svc) {
+func (r *CloudMapReconciler) updateServiceImport(ctx context.Context, svcImport *v1alpha1.ServiceImport, svc *v1.Service, importedSvcPorts []*model.Port) error {
+	updateRequired := false
+	if len(svcImport.Spec.IPs) != 1 || svcImport.Spec.IPs[0] != svc.Spec.ClusterIP {
+		r.Log.Debug("ServiceImport IP need update", "ServiceImport IPs", svcImport.Spec.IPs, "cluster IP", svc.Spec.ClusterIP)
 		svcImport.Spec.IPs = []string{svc.Spec.ClusterIP}
+		updateRequired = true
+	}
 
-		svcImport.Spec.Ports = make([]v1alpha1.ServicePort, 0)
-		for _, p := range svc.Spec.Ports {
-			svcImport.Spec.Ports = append(svcImport.Spec.Ports, servicePortToServiceImport(p))
+	// ServiceImport ports do not have TargetPort, exclude field for purpose of comparison
+	simplifiedSvcPorts := make([]*model.Port, 0)
+	for _, svcPort := range importedSvcPorts {
+		simplifiedSvcPorts = append(simplifiedSvcPorts, &model.Port{
+			Name:     svcPort.Name,
+			Port:     svcPort.Port,
+			Protocol: svcPort.Protocol,
+		})
+	}
+
+	svcImportPorts := make([]*model.Port, 0)
+	for _, importPort := range svcImport.Spec.Ports {
+		port := ServiceImportPortToPort(importPort)
+		svcImportPorts = append(svcImportPorts, &port)
+	}
+
+	if !PortsEqualIgnoreOrder(svcImportPorts, simplifiedSvcPorts) {
+		r.Log.Debug("ServiceImport ports need update", "ServiceImport Ports", svcImport.Spec.Ports, "imported ports", importedSvcPorts)
+		serviceImportPorts := make([]v1alpha1.ServicePort, 0)
+		for _, port := range importedSvcPorts {
+			serviceImportPorts = append(serviceImportPorts, PortToServiceImportPort(*port))
 		}
+		svcImport.Spec.Ports = serviceImportPorts
+		updateRequired = true
+	}
+
+	if updateRequired {
 		if err := r.Client.Update(ctx, svcImport); err != nil {
 			return err
 		}
@@ -420,22 +273,27 @@ func (r *CloudMapReconciler) updateServiceImport(ctx context.Context, svcImport 
 	return nil
 }
 
-func portsEqual(svcImport *v1alpha1.ServiceImport, svc *v1.Service) bool {
-	impPorts := svcImport.Spec.Ports
-	svcPorts := make([]v1alpha1.ServicePort, 0)
+func (r *CloudMapReconciler) updateDerivedService(ctx context.Context, svc *v1.Service, importedSvcPorts []*model.Port) error {
+	svcPorts := make([]*model.Port, 0)
 	for _, p := range svc.Spec.Ports {
-		svcPorts = append(svcPorts, servicePortToServiceImport(p))
+		port := ServicePortToPort(p)
+		svcPorts = append(svcPorts, &port)
 	}
 
-	// TODO: consider order
-	return reflect.DeepEqual(impPorts, svcPorts)
-}
+	portsMatch := PortsEqualIgnoreOrder(importedSvcPorts, svcPorts)
+	if !portsMatch {
+		newSvcPorts := make([]v1.ServicePort, 0)
+		for _, importPort := range importedSvcPorts {
+			newSvcPorts = append(newSvcPorts, PortToServicePort(*importPort))
+		}
 
-func servicePortToServiceImport(port v1.ServicePort) v1alpha1.ServicePort {
-	return v1alpha1.ServicePort{
-		Name:        port.Name,
-		Protocol:    port.Protocol,
-		AppProtocol: port.AppProtocol,
-		Port:        port.Port,
+		svc.Spec.Ports = newSvcPorts
+		if err := r.Client.Update(ctx, svc); err != nil {
+			return err
+		}
+		r.Log.Info("updated derived Service",
+			"namespace", svc.Namespace, "name", svc.Name, "ports", svc.Spec.Ports)
 	}
+
+	return nil
 }

--- a/pkg/controllers/cloudmap_controller.go
+++ b/pkg/controllers/cloudmap_controller.go
@@ -194,8 +194,13 @@ func (r *CloudMapReconciler) updateEndpointSlices(ctx context.Context, svcImport
 		return err
 	}
 
+	existingSlices := make([]*discovery.EndpointSlice, 0)
+	for _, existingSlice := range existingSlicesList.Items {
+		existingSlices = append(existingSlices, &existingSlice)
+	}
+
 	plan := EndpointSlicePlan{
-		Current:           existingSlicesList.Items,
+		Current:           existingSlices,
 		Desired:           desiredEndpoints,
 		Service:           svc,
 		ServiceImportName: svcImport.Name,

--- a/pkg/controllers/cloudmap_controller_test.go
+++ b/pkg/controllers/cloudmap_controller_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/discovery/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -25,7 +24,7 @@ import (
 
 func TestCloudMapReconciler_Reconcile(t *testing.T) {
 	// create a fake controller client and add some objects
-	objs := []runtime.Object{testNamespace()}
+	objs := []runtime.Object{k8sNamespaceForTest()}
 
 	s := scheme.Scheme
 	s.AddKnownTypes(v1alpha1.GroupVersion, &v1alpha1.ServiceImportList{}, &v1alpha1.ServiceImport{})
@@ -71,15 +70,6 @@ func TestCloudMapReconciler_Reconcile(t *testing.T) {
 	assert.Equal(t, test.SvcName, endpointSlice.Labels["multicluster.kubernetes.io/service-name"], "Endpoint slice is created")
 	assert.Equal(t, int32(test.Port1), *endpointSlice.Ports[0].Port)
 	assert.Equal(t, test.EndptIp1, endpointSlice.Endpoints[0].Addresses[0])
-}
-
-func testNamespace() *v1.Namespace {
-	return &v1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      test.NsName,
-			Namespace: test.NsName,
-		},
-	}
 }
 
 func getReconciler(t *testing.T, mockSDClient *cloudmap.MockServiceDiscoveryClient, client client.Client) *CloudMapReconciler {

--- a/pkg/controllers/common_test.go
+++ b/pkg/controllers/common_test.go
@@ -1,0 +1,83 @@
+package controllers
+
+import (
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/api/v1alpha1"
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/test"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func k8sNamespaceForTest() *v1.Namespace {
+	return &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      test.NsName,
+			Namespace: test.NsName,
+		},
+	}
+}
+
+func k8sServiceForTest() *v1.Service {
+	return &v1.Service{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      test.SvcName,
+			Namespace: test.NsName,
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:       test.PortName1,
+				Protocol:   test.Protocol1,
+				Port:       test.ServicePort1,
+				TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: test.Port1},
+			}},
+		},
+		Status: v1.ServiceStatus{},
+	}
+}
+
+func serviceExportForTest() *v1alpha1.ServiceExport {
+	return &v1alpha1.ServiceExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      test.SvcName,
+			Namespace: test.NsName,
+		},
+	}
+}
+
+func endpointSliceForTest() *discovery.EndpointSlice {
+	port := int32(test.Port1)
+	protocol := v1.ProtocolTCP
+	return &discovery.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: test.NsName,
+			Name:      test.SvcName + "-slice",
+			Labels:    map[string]string{discovery.LabelServiceName: test.SvcName},
+		},
+		AddressType: discovery.AddressTypeIPv4,
+		Endpoints: []discovery.Endpoint{{
+			Addresses: []string{test.EndptIp1},
+		}},
+		Ports: []discovery.EndpointPort{{
+			Name:     aws.String(test.PortName1),
+			Protocol: &protocol,
+			Port:     &port,
+		}},
+	}
+}
+
+func endpointSliceWithIpsAndPortsForTest(ips []string, ports []discovery.EndpointPort) *discovery.EndpointSlice {
+	svc := k8sServiceForTest()
+	slice := CreateEndpointSliceStruct(svc, test.SvcName)
+	slice.Ports = ports
+
+	testEndpoints := make([]discovery.Endpoint, 0)
+	for _, ip := range ips {
+		testEndpoints = append(testEndpoints, CreateEndpointForSlice(svc, ip))
+	}
+	slice.Endpoints = testEndpoints
+
+	return slice
+}

--- a/pkg/controllers/controllers_common_test.go
+++ b/pkg/controllers/controllers_common_test.go
@@ -10,6 +10,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+// Factory functions for testing
+
 func k8sNamespaceForTest() *v1.Namespace {
 	return &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/endpointslice_plan.go
+++ b/pkg/controllers/endpointslice_plan.go
@@ -1,0 +1,176 @@
+package controllers
+
+import (
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
+	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1beta1"
+)
+
+const defaultMaxEndpointsPerSlice = 100
+
+type EndpointSliceChanges struct {
+	// Create: List of EndpointSlices that need to be created
+	Create []*discovery.EndpointSlice
+	// Update: List of EndpointSlices that need to be updated
+	Update []*discovery.EndpointSlice
+	// Delete: List of EndpointSlices that need to be deleted
+	Delete []*discovery.EndpointSlice
+	// Unmodified: List of EndpointSlices that do not need to be changed
+	Unmodified []*discovery.EndpointSlice
+}
+
+type EndpointSlicePlan struct {
+	// maxEndpointsPerSlice defaults to 100
+	maxEndpointsPerSlice int
+
+	// Service to reconcile endpoints in
+	Service *v1.Service
+
+	// ServiceImportName name used to create new EndpointSlices
+	ServiceImportName string
+
+	// Current EndpontSlices
+	Current []discovery.EndpointSlice
+
+	// Desired Endpoints
+	Desired []*model.Endpoint
+}
+
+// CalculateChanges returns list of EndpointSlice Changes that need to applied
+func (p *EndpointSlicePlan) CalculateChanges() EndpointSliceChanges {
+	// populate map of desired endpoints for lookup efficiency
+	desiredEndpoints := make(map[string]*model.Endpoint)
+	for _, desiredEndpoint := range p.Desired {
+		desiredEndpoints[desiredEndpoint.IP] = desiredEndpoint
+	}
+
+	desiredPorts := ExtractEndpointPorts(p.Desired)
+
+	// Remove unwanted endpoints from slices
+	changes := p.trimSlices(desiredEndpoints, desiredPorts)
+
+	// Add new endpoints to slices
+	for len(desiredEndpoints) > 0 {
+		sliceWithRoom, needsPortUpdate := p.getOrCreateUnfilledEndpointSlice(&changes, len(desiredEndpoints))
+
+		for key, endpointToAdd := range desiredEndpoints {
+			roomInSlice := p.getMaxEndpointsPerSlice() - len(sliceWithRoom.Endpoints)
+			if roomInSlice <= 0 {
+				// stop adding to slice once it is full
+				break
+			}
+			sliceWithRoom.Endpoints = append(sliceWithRoom.Endpoints, CreateEndpointForSlice(p.Service, endpointToAdd.IP))
+			delete(desiredEndpoints, key)
+		}
+
+		if needsPortUpdate {
+			newPorts := portSliceToEndpointPortSlice(desiredPorts)
+			sliceWithRoom.Ports = newPorts
+		}
+	}
+
+	return changes
+}
+
+func (p *EndpointSlicePlan) trimSlices(desiredEndpoints map[string]*model.Endpoint, desiredPorts []*model.Port) (changes EndpointSliceChanges) {
+	// remove all undesired existing endpoints in slices
+	for _, existingSlice := range p.Current {
+		updatedEndpointList := make([]discovery.Endpoint, 0)
+		for _, existingEndpoint := range existingSlice.Endpoints {
+			key := existingEndpoint.Addresses[0]
+			if _, found := desiredEndpoints[key]; found {
+				updatedEndpointList = append(updatedEndpointList, existingEndpoint)
+				delete(desiredEndpoints, key)
+			}
+		}
+
+		// mark slice for deletion if all endpoints were removed
+		if len(updatedEndpointList) == 0 {
+			sliceRef := existingSlice
+			changes.Delete = append(changes.Delete, &sliceRef)
+			continue
+		}
+
+		sliceNeedsUpdate := false
+
+		// slice needs to be updated if ports do not match
+		if !PortsEqualIgnoreOrder(desiredPorts, endpointPortSliceToPortSlice(existingSlice.Ports)) {
+			existingSlice.Ports = portSliceToEndpointPortSlice(desiredPorts)
+			sliceNeedsUpdate = true
+		}
+
+		// slice needs to be updated if endpoint list changed
+		if len(updatedEndpointList) != len(existingSlice.Endpoints) {
+			existingSlice.Endpoints = updatedEndpointList
+			sliceNeedsUpdate = true
+		}
+
+		sliceRef := existingSlice
+		if sliceNeedsUpdate {
+			changes.Update = append(changes.Update, &sliceRef)
+		} else {
+			changes.Unmodified = append(changes.Unmodified, &sliceRef)
+		}
+	}
+
+	return changes
+}
+
+func (p *EndpointSlicePlan) getOrCreateUnfilledEndpointSlice(changes *EndpointSliceChanges, requiredCapacity int) (sliceWithRoom *discovery.EndpointSlice, needsPortUpdate bool) {
+	// Prefer slices we are already updating
+	for _, sliceToUpdate := range changes.Update {
+		if len(sliceToUpdate.Endpoints) < p.getMaxEndpointsPerSlice() {
+			return sliceToUpdate, false
+		}
+	}
+
+	// Update a slice marked for deletion if possible
+	if len(changes.Delete) > 0 {
+		sliceToReuse := changes.Delete[0]
+		changes.Delete = changes.Delete[1:]
+		changes.Update = append(changes.Update, sliceToReuse)
+
+		// clear endpoint list that was marked for deletion before reusing
+		sliceToReuse.Endpoints = []discovery.Endpoint{}
+		return sliceToReuse, true
+	}
+
+	// Update an unmodified slice if it has capacity to add all endpoints
+	for i, unmodifiedSlice := range changes.Unmodified {
+		proposedSliceLength := len(unmodifiedSlice.Endpoints) + requiredCapacity
+		if proposedSliceLength <= p.getMaxEndpointsPerSlice() {
+			changes.Unmodified = append(changes.Unmodified[:i], changes.Unmodified[i+1:]...)
+			changes.Update = append(changes.Update, unmodifiedSlice)
+			return unmodifiedSlice, false
+		}
+	}
+
+	// No existing slices can fill new endpoint requirements so create a new slice
+	sliceToCreate := CreateEndpointSliceStruct(p.Service, p.ServiceImportName)
+	changes.Create = append(changes.Create, sliceToCreate)
+	return sliceToCreate, true
+}
+
+func (p *EndpointSlicePlan) getMaxEndpointsPerSlice() int {
+	if p.maxEndpointsPerSlice != 0 {
+		return p.maxEndpointsPerSlice
+	}
+
+	return defaultMaxEndpointsPerSlice
+}
+
+func endpointPortSliceToPortSlice(endpointPorts []discovery.EndpointPort) (ports []*model.Port) {
+	for _, endpointPort := range endpointPorts {
+		port := EndpointPortToPort(endpointPort)
+		ports = append(ports, &port)
+	}
+	return ports
+}
+
+func portSliceToEndpointPortSlice(ports []*model.Port) (endpointPorts []discovery.EndpointPort) {
+	for _, port := range ports {
+		endpointPort := PortToEndpointPort(*port)
+		endpointPorts = append(endpointPorts, endpointPort)
+	}
+	return endpointPorts
+}

--- a/pkg/controllers/endpointslice_plan.go
+++ b/pkg/controllers/endpointslice_plan.go
@@ -30,7 +30,7 @@ type EndpointSlicePlan struct {
 	ServiceImportName string
 
 	// Current EndpontSlices
-	Current []discovery.EndpointSlice
+	Current []*discovery.EndpointSlice
 
 	// Desired Endpoints
 	Desired []*model.Endpoint
@@ -86,8 +86,7 @@ func (p *EndpointSlicePlan) trimSlices(desiredEndpoints map[string]*model.Endpoi
 
 		// mark slice for deletion if all endpoints were removed
 		if len(updatedEndpointList) == 0 {
-			sliceRef := existingSlice
-			changes.Delete = append(changes.Delete, &sliceRef)
+			changes.Delete = append(changes.Delete, existingSlice)
 			continue
 		}
 
@@ -105,11 +104,10 @@ func (p *EndpointSlicePlan) trimSlices(desiredEndpoints map[string]*model.Endpoi
 			sliceNeedsUpdate = true
 		}
 
-		sliceRef := existingSlice
 		if sliceNeedsUpdate {
-			changes.Update = append(changes.Update, &sliceRef)
+			changes.Update = append(changes.Update, existingSlice)
 		} else {
-			changes.Unmodified = append(changes.Unmodified, &sliceRef)
+			changes.Unmodified = append(changes.Unmodified, existingSlice)
 		}
 	}
 

--- a/pkg/controllers/endpointslice_plan_test.go
+++ b/pkg/controllers/endpointslice_plan_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestEndpointSlicePlan_CalculateChanges(t *testing.T) {
 	type fields struct {
-		Current []discovery.EndpointSlice
+		Current []*discovery.EndpointSlice
 		Desired []*model.Endpoint
 	}
 	tests := []struct {
@@ -24,7 +24,7 @@ func TestEndpointSlicePlan_CalculateChanges(t *testing.T) {
 		{
 			name: "no changes",
 			fields: fields{
-				Current: []discovery.EndpointSlice{*endpointSliceForTest()},
+				Current: []*discovery.EndpointSlice{endpointSliceForTest()},
 				Desired: []*model.Endpoint{test.GetTestEndpoint1()},
 			},
 			want: EndpointSliceChanges{
@@ -34,7 +34,7 @@ func TestEndpointSlicePlan_CalculateChanges(t *testing.T) {
 		{
 			name: "delete slice",
 			fields: fields{
-				Current: []discovery.EndpointSlice{*endpointSliceForTest()},
+				Current: []*discovery.EndpointSlice{endpointSliceForTest()},
 				Desired: []*model.Endpoint{},
 			},
 			want: EndpointSliceChanges{
@@ -44,7 +44,7 @@ func TestEndpointSlicePlan_CalculateChanges(t *testing.T) {
 		{
 			name: "new slice",
 			fields: fields{
-				Current: []discovery.EndpointSlice{},
+				Current: []*discovery.EndpointSlice{},
 				Desired: []*model.Endpoint{test.GetTestEndpoint1()},
 			},
 			want: EndpointSliceChanges{
@@ -61,8 +61,8 @@ func TestEndpointSlicePlan_CalculateChanges(t *testing.T) {
 		{
 			name: "removed endpoint needs slice update",
 			fields: fields{
-				Current: []discovery.EndpointSlice{
-					*endpointSliceWithIpsAndPortsForTest(
+				Current: []*discovery.EndpointSlice{
+					endpointSliceWithIpsAndPortsForTest(
 						[]string{test.EndptIp1, test.EndptIp2},
 						[]discovery.EndpointPort{
 							PortToEndpointPort(test.GetTestEndpoint1().EndpointPort),
@@ -85,8 +85,8 @@ func TestEndpointSlicePlan_CalculateChanges(t *testing.T) {
 		{
 			name: "added endpoint needs slice update",
 			fields: fields{
-				Current: []discovery.EndpointSlice{
-					*endpointSliceWithIpsAndPortsForTest(
+				Current: []*discovery.EndpointSlice{
+					endpointSliceWithIpsAndPortsForTest(
 						[]string{test.EndptIp1},
 						[]discovery.EndpointPort{
 							PortToEndpointPort(model.Port{Name: test.PortName1, Port: test.Port1, Protocol: test.Protocol1}),
@@ -121,8 +121,8 @@ func TestEndpointSlicePlan_CalculateChanges(t *testing.T) {
 		{
 			name: "swapped endpoints need slice update",
 			fields: fields{
-				Current: []discovery.EndpointSlice{
-					*endpointSliceWithIpsAndPortsForTest(
+				Current: []*discovery.EndpointSlice{
+					endpointSliceWithIpsAndPortsForTest(
 						[]string{test.EndptIp1},
 						[]discovery.EndpointPort{
 							PortToEndpointPort(test.GetTestEndpoint2().EndpointPort),
@@ -148,8 +148,8 @@ func TestEndpointSlicePlan_CalculateChanges(t *testing.T) {
 		{
 			name: "changed ports need slice update",
 			fields: fields{
-				Current: []discovery.EndpointSlice{
-					*endpointSliceWithIpsAndPortsForTest(
+				Current: []*discovery.EndpointSlice{
+					endpointSliceWithIpsAndPortsForTest(
 						[]string{test.EndptIp2},
 						[]discovery.EndpointPort{
 							PortToEndpointPort(test.GetTestEndpoint1().EndpointPort),
@@ -194,7 +194,7 @@ func TestEndpointSlicePlan_MultipleSliceCreation(t *testing.T) {
 		maxEndpointsPerSlice: 2,
 		Service:              k8sServiceForTest(),
 		ServiceImportName:    test.SvcName,
-		Current:              []discovery.EndpointSlice{},
+		Current:              []*discovery.EndpointSlice{},
 		Desired:              test.GetTestEndpoints(43),
 	}
 	changes := p.CalculateChanges()
@@ -206,7 +206,7 @@ func TestEndpointSlicePlan_PreferCreateOverMultipleSliceUpdate(t *testing.T) {
 		maxEndpointsPerSlice: 2,
 		Service:              k8sServiceForTest(),
 		ServiceImportName:    test.SvcName,
-		Current:              []discovery.EndpointSlice{*endpointSliceForTest()},
+		Current:              []*discovery.EndpointSlice{endpointSliceForTest()},
 		Desired:              []*model.Endpoint{test.GetTestEndpoint1()},
 	}
 	p.Desired = append(p.Desired, test.GetTestEndpoints(2)...)

--- a/pkg/controllers/endpointslice_plan_test.go
+++ b/pkg/controllers/endpointslice_plan_test.go
@@ -1,0 +1,218 @@
+package controllers
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/test"
+	"github.com/stretchr/testify/assert"
+	discovery "k8s.io/api/discovery/v1beta1"
+)
+
+func TestEndpointSlicePlan_CalculateChanges(t *testing.T) {
+	type fields struct {
+		Current []discovery.EndpointSlice
+		Desired []*model.Endpoint
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   EndpointSliceChanges
+	}{
+		{
+			name: "no changes",
+			fields: fields{
+				Current: []discovery.EndpointSlice{*endpointSliceForTest()},
+				Desired: []*model.Endpoint{test.GetTestEndpoint1()},
+			},
+			want: EndpointSliceChanges{
+				Unmodified: []*discovery.EndpointSlice{endpointSliceForTest()},
+			},
+		},
+		{
+			name: "delete slice",
+			fields: fields{
+				Current: []discovery.EndpointSlice{*endpointSliceForTest()},
+				Desired: []*model.Endpoint{},
+			},
+			want: EndpointSliceChanges{
+				Delete: []*discovery.EndpointSlice{endpointSliceForTest()},
+			},
+		},
+		{
+			name: "new slice",
+			fields: fields{
+				Current: []discovery.EndpointSlice{},
+				Desired: []*model.Endpoint{test.GetTestEndpoint1()},
+			},
+			want: EndpointSliceChanges{
+				Create: []*discovery.EndpointSlice{
+					endpointSliceWithIpsAndPortsForTest(
+						[]string{test.EndptIp1},
+						[]discovery.EndpointPort{
+							PortToEndpointPort(test.GetTestEndpoint1().EndpointPort),
+						},
+					),
+				},
+			},
+		},
+		{
+			name: "removed endpoint needs slice update",
+			fields: fields{
+				Current: []discovery.EndpointSlice{
+					*endpointSliceWithIpsAndPortsForTest(
+						[]string{test.EndptIp1, test.EndptIp2},
+						[]discovery.EndpointPort{
+							PortToEndpointPort(test.GetTestEndpoint1().EndpointPort),
+						},
+					),
+				},
+				Desired: []*model.Endpoint{test.GetTestEndpoint2()},
+			},
+			want: EndpointSliceChanges{
+				Update: []*discovery.EndpointSlice{
+					endpointSliceWithIpsAndPortsForTest(
+						[]string{test.EndptIp2},
+						[]discovery.EndpointPort{
+							PortToEndpointPort(test.GetTestEndpoint2().EndpointPort),
+						},
+					),
+				},
+			},
+		},
+		{
+			name: "added endpoint needs slice update",
+			fields: fields{
+				Current: []discovery.EndpointSlice{
+					*endpointSliceWithIpsAndPortsForTest(
+						[]string{test.EndptIp1},
+						[]discovery.EndpointPort{
+							PortToEndpointPort(model.Port{Name: test.PortName1, Port: test.Port1, Protocol: test.Protocol1}),
+						},
+					),
+				},
+				Desired: []*model.Endpoint{
+					test.GetTestEndpoint1(),
+					{
+						Id: test.EndptId2,
+						IP: test.EndptIp2,
+						EndpointPort: model.Port{
+							Name:     test.PortName1,
+							Port:     test.Port1,
+							Protocol: test.Protocol1,
+						},
+					},
+				},
+			},
+			want: EndpointSliceChanges{
+				Update: []*discovery.EndpointSlice{
+					endpointSliceWithIpsAndPortsForTest(
+						[]string{test.EndptIp1, test.EndptIp2},
+						[]discovery.EndpointPort{
+							PortToEndpointPort(test.GetTestEndpoint1().EndpointPort),
+						},
+					),
+				},
+				Unmodified: []*discovery.EndpointSlice{},
+			},
+		},
+		{
+			name: "swapped endpoints need slice update",
+			fields: fields{
+				Current: []discovery.EndpointSlice{
+					*endpointSliceWithIpsAndPortsForTest(
+						[]string{test.EndptIp1},
+						[]discovery.EndpointPort{
+							PortToEndpointPort(test.GetTestEndpoint2().EndpointPort),
+						},
+					),
+				},
+				Desired: []*model.Endpoint{
+					test.GetTestEndpoint2(),
+				},
+			},
+			want: EndpointSliceChanges{
+				Update: []*discovery.EndpointSlice{
+					endpointSliceWithIpsAndPortsForTest(
+						[]string{test.EndptIp2},
+						[]discovery.EndpointPort{
+							PortToEndpointPort(test.GetTestEndpoint2().EndpointPort),
+						},
+					),
+				},
+				Delete: []*discovery.EndpointSlice{},
+			},
+		},
+		{
+			name: "changed ports need slice update",
+			fields: fields{
+				Current: []discovery.EndpointSlice{
+					*endpointSliceWithIpsAndPortsForTest(
+						[]string{test.EndptIp2},
+						[]discovery.EndpointPort{
+							PortToEndpointPort(test.GetTestEndpoint1().EndpointPort),
+						},
+					),
+				},
+				Desired: []*model.Endpoint{
+					test.GetTestEndpoint2(),
+				},
+			},
+			want: EndpointSliceChanges{
+				Update: []*discovery.EndpointSlice{
+					endpointSliceWithIpsAndPortsForTest(
+						[]string{test.EndptIp2},
+						[]discovery.EndpointPort{
+							PortToEndpointPort(test.GetTestEndpoint2().EndpointPort),
+						},
+					),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &EndpointSlicePlan{
+				Service:           k8sServiceForTest(),
+				ServiceImportName: test.SvcName,
+				Current:           tt.fields.Current,
+				Desired:           tt.fields.Desired,
+			}
+			if got := p.CalculateChanges(); !reflect.DeepEqual(got, tt.want) {
+				gotJson, _ := json.MarshalIndent(got, "", "  ")
+				wantJson, _ := json.MarshalIndent(tt.want, "", "  ")
+				t.Errorf("CalculateChanges() = \n%s\nwant = \n%s", gotJson, wantJson)
+			}
+		})
+	}
+}
+
+func TestEndpointSlicePlan_MultipleSliceCreation(t *testing.T) {
+	p := &EndpointSlicePlan{
+		maxEndpointsPerSlice: 2,
+		Service:              k8sServiceForTest(),
+		ServiceImportName:    test.SvcName,
+		Current:              []discovery.EndpointSlice{},
+		Desired:              test.GetTestEndpoints(43),
+	}
+	changes := p.CalculateChanges()
+	assert.Equal(t, 22, len(changes.Create))
+}
+
+func TestEndpointSlicePlan_PreferCreateOverMultipleSliceUpdate(t *testing.T) {
+	p := &EndpointSlicePlan{
+		maxEndpointsPerSlice: 2,
+		Service:              k8sServiceForTest(),
+		ServiceImportName:    test.SvcName,
+		Current:              []discovery.EndpointSlice{*endpointSliceForTest()},
+		Desired:              []*model.Endpoint{test.GetTestEndpoint1()},
+	}
+	p.Desired = append(p.Desired, test.GetTestEndpoints(2)...)
+	changes := p.CalculateChanges()
+	assert.Equal(t, 1, len(changes.Create))
+	assert.Equal(t, 1, len(changes.Unmodified))
+	assert.Equal(t, 0, len(changes.Update))
+	assert.Equal(t, 0, len(changes.Delete))
+}

--- a/pkg/controllers/serviceexport_controller.go
+++ b/pkg/controllers/serviceexport_controller.go
@@ -40,7 +40,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1alpha1 "github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/api/v1alpha1"
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/api/v1alpha1"
 )
 
 const (

--- a/pkg/controllers/utils.go
+++ b/pkg/controllers/utils.go
@@ -116,7 +116,12 @@ func PortsEqualIgnoreOrder(a, b []*model.Port) (equal bool) {
 	}
 
 	for _, portB := range b {
-		if !portB.Equals(aMap[portB.GetID()]) {
+		portA, found := aMap[portB.GetID()]
+		if !found {
+			return false
+		}
+
+		if !portB.Equals(portA) {
 			return false
 		}
 	}

--- a/pkg/controllers/utils.go
+++ b/pkg/controllers/utils.go
@@ -1,42 +1,77 @@
 package controllers
 
 import (
-	"reflect"
+	"crypto/sha256"
+	"encoding/base32"
+	"strings"
 
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/api/v1alpha1"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+const (
+	// DerivedServiceAnnotation annotates a ServiceImport with derived Service name
+	DerivedServiceAnnotation = "multicluster.k8s.aws/derived-service"
+
+	// LabelServiceImportName indicates the name of the multi-cluster service that an EndpointSlice belongs to.
+	LabelServiceImportName = "multicluster.kubernetes.io/service-name"
+)
+
+// ServicePortToPort converts a k8s service port to internal model port
 func ServicePortToPort(svcPort v1.ServicePort) model.Port {
 	return model.Port{
 		Name:       svcPort.Name,
 		Port:       svcPort.Port,
 		TargetPort: svcPort.TargetPort.String(),
-		Protocol:   protocolToString(svcPort.Protocol),
+		Protocol:   string(svcPort.Protocol),
 	}
 }
 
+// ServiceImportPortToPort converts a service import port to an internal model port
+func ServiceImportPortToPort(svcPort v1alpha1.ServicePort) model.Port {
+	return model.Port{
+		Name:     svcPort.Name,
+		Port:     svcPort.Port,
+		Protocol: string(svcPort.Protocol),
+	}
+}
+
+// EndpointPortToPort converts a k8s endpoint port to an internal model port
 func EndpointPortToPort(port discovery.EndpointPort) model.Port {
 	return model.Port{
 		Name:     *port.Name,
 		Port:     *port.Port,
-		Protocol: protocolToString(*port.Protocol),
+		Protocol: string(*port.Protocol),
 	}
 }
 
+// PortToServicePort converts an internal model port to a k8s service port
 func PortToServicePort(port model.Port) v1.ServicePort {
 	return v1.ServicePort{
 		Name:       port.Name,
-		Protocol:   stringToProtocol(port.Protocol),
+		Protocol:   v1.Protocol(port.Protocol),
 		Port:       port.Port,
 		TargetPort: intstr.Parse(port.TargetPort),
 	}
 }
 
+// PortToServiceImportPort converts an internal model port to a service import port
+func PortToServiceImportPort(port model.Port) v1alpha1.ServicePort {
+	return v1alpha1.ServicePort{
+		Name:     port.Name,
+		Protocol: v1.Protocol(port.Protocol),
+		Port:     port.Port,
+	}
+}
+
+// PortToEndpointPort converts an internal model port to a k8s endpoint port
 func PortToEndpointPort(port model.Port) discovery.EndpointPort {
-	protocol := stringToProtocol(port.Protocol)
+	protocol := v1.Protocol(port.Protocol)
 	return discovery.EndpointPort{
 		Name:     &port.Name,
 		Protocol: &protocol,
@@ -44,48 +79,135 @@ func PortToEndpointPort(port model.Port) discovery.EndpointPort {
 	}
 }
 
-func protocolToString(protocol v1.Protocol) string {
-	switch protocol {
-	case v1.ProtocolTCP:
-		return model.TCPProtocol
-	case v1.ProtocolUDP:
-		return model.UDPProtocol
-	case v1.ProtocolSCTP:
-		return model.SCTPProtocol
-	default:
-		return ""
+// ExtractServicePorts extracts all unique service ports from a slice of endpoints
+func ExtractServicePorts(endpoints []*model.Endpoint) (servicePorts []*model.Port) {
+	uniquePorts := make(map[string]model.Port)
+	for _, ep := range endpoints {
+		uniquePorts[ep.ServicePort.GetID()] = ep.ServicePort
 	}
+	for _, servicePort := range uniquePorts {
+		portRef := servicePort
+		servicePorts = append(servicePorts, &portRef)
+	}
+	return servicePorts
 }
 
-func stringToProtocol(protocol string) v1.Protocol {
-	switch protocol {
-	case model.TCPProtocol:
-		return v1.ProtocolTCP
-	case model.UDPProtocol:
-		return v1.ProtocolUDP
-	case model.SCTPProtocol:
-		return v1.ProtocolSCTP
-	default:
-		return ""
+// ExtractEndpointPorts extracts all unique endpoint ports from a slice of endpoints
+func ExtractEndpointPorts(endpoints []*model.Endpoint) (endpointPorts []*model.Port) {
+	uniquePorts := make(map[string]model.Port)
+	for _, ep := range endpoints {
+		uniquePorts[ep.EndpointPort.GetID()] = ep.EndpointPort
 	}
+	for _, endpointPort := range uniquePorts {
+		portRef := endpointPort
+		endpointPorts = append(endpointPorts, &portRef)
+	}
+	return endpointPorts
 }
 
-func EndpointPortsAreEqualIgnoreOrder(a, b []discovery.EndpointPort) (equal bool) {
+func PortsEqualIgnoreOrder(a, b []*model.Port) (equal bool) {
 	if len(a) != len(b) {
 		return false
 	}
 
-	for _, aPort := range a {
-		match := false
-		for _, bPort := range b {
-			if reflect.DeepEqual(aPort, bPort) {
-				match = true
-				break
-			}
-		}
-		if !match {
+	aMap := make(map[string]*model.Port)
+	for _, portA := range a {
+		aMap[portA.GetID()] = portA
+	}
+
+	for _, portB := range b {
+		if !portB.Equals(aMap[portB.GetID()]) {
 			return false
 		}
 	}
 	return true
+}
+
+// DerivedName computes the "placeholder" name for an imported service
+func DerivedName(namespace string, name string) string {
+	hash := sha256.New()
+	hash.Write([]byte(namespace + name))
+	return "imported-" + strings.ToLower(base32.HexEncoding.WithPadding(base32.NoPadding).EncodeToString(hash.Sum(nil)))[:10]
+}
+
+// CreateServiceImportStruct creates struct representation of a ServiceImport
+func CreateServiceImportStruct(namespace string, name string, servicePorts []*model.Port) *v1alpha1.ServiceImport {
+	serviceImportPorts := make([]v1alpha1.ServicePort, 0)
+	for _, port := range servicePorts {
+		serviceImportPorts = append(serviceImportPorts, PortToServiceImportPort(*port))
+	}
+
+	return &v1alpha1.ServiceImport{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   namespace,
+			Name:        name,
+			Annotations: map[string]string{DerivedServiceAnnotation: DerivedName(namespace, name)},
+		},
+		Spec: v1alpha1.ServiceImportSpec{
+			IPs:   []string{},
+			Type:  v1alpha1.ClusterSetIP,
+			Ports: serviceImportPorts,
+		},
+	}
+}
+
+// CreateDerivedServiceStruct creates struct representation of a derived service
+func CreateDerivedServiceStruct(svcImport *v1alpha1.ServiceImport, importedSvcPorts []*model.Port) *v1.Service {
+	ownerRef := metav1.NewControllerRef(svcImport, schema.GroupVersionKind{
+		Version: svcImport.TypeMeta.APIVersion,
+		Kind:    svcImport.TypeMeta.Kind,
+	})
+
+	svcPorts := make([]v1.ServicePort, 0)
+	for _, svcPort := range importedSvcPorts {
+		svcPorts = append(svcPorts, PortToServicePort(*svcPort))
+	}
+
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       svcImport.Namespace,
+			Name:            svcImport.Annotations[DerivedServiceAnnotation],
+			OwnerReferences: []metav1.OwnerReference{*ownerRef},
+		},
+		Spec: v1.ServiceSpec{
+			Type:  v1.ServiceTypeClusterIP,
+			Ports: svcPorts,
+		},
+	}
+}
+
+func CreateEndpointForSlice(svc *v1.Service, ip string) discovery.Endpoint {
+	t := true
+
+	return discovery.Endpoint{
+		Addresses: []string{ip},
+		Conditions: discovery.EndpointConditions{
+			Ready: &t,
+		},
+		TargetRef: &v1.ObjectReference{
+			Kind:            "Service",
+			Namespace:       svc.Namespace,
+			Name:            svc.Name,
+			UID:             svc.ObjectMeta.UID,
+			ResourceVersion: svc.ObjectMeta.ResourceVersion,
+		},
+	}
+}
+
+func CreateEndpointSliceStruct(svc *v1.Service, svcImportName string) *discovery.EndpointSlice {
+	return &discovery.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				discovery.LabelServiceName: svc.Name,      // derived Service name
+				LabelServiceImportName:     svcImportName, // original ServiceImport name
+			},
+			GenerateName: svc.Name + "-",
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(svc, schema.GroupVersionKind{
+				Version: svc.TypeMeta.APIVersion,
+				Kind:    svc.TypeMeta.Kind,
+			})},
+			Namespace: svc.Namespace,
+		},
+		AddressType: discovery.AddressTypeIPv4,
+	}
 }

--- a/pkg/controllers/utils_test.go
+++ b/pkg/controllers/utils_test.go
@@ -4,9 +4,12 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/api/v1alpha1"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/test"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/discovery/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -44,6 +47,40 @@ func TestServicePortToPort(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := ServicePortToPort(tt.args.svcPort); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ServicePortToPort() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestServiceImportPortToPort(t *testing.T) {
+	type args struct {
+		svcImportPort v1alpha1.ServicePort
+	}
+	tests := []struct {
+		name string
+		args args
+		want model.Port
+	}{
+		{
+			name: "happy case",
+			args: args{
+				svcImportPort: v1alpha1.ServicePort{
+					Name:     test.PortName1,
+					Protocol: v1.ProtocolTCP,
+					Port:     80,
+				},
+			},
+			want: model.Port{
+				Name:     test.PortName1,
+				Port:     80,
+				Protocol: test.Protocol1,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ServiceImportPortToPort(tt.args.svcImportPort); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ServiceImportPortToPort() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -146,6 +183,41 @@ func TestPortToServicePort(t *testing.T) {
 	}
 }
 
+func TestPortToServiceImportPort(t *testing.T) {
+	type args struct {
+		port model.Port
+	}
+	tests := []struct {
+		name string
+		args args
+		want v1alpha1.ServicePort
+	}{
+		{
+			name: "happy case",
+			args: args{
+				port: model.Port{
+					Name:       test.PortName1,
+					Port:       test.Port1,
+					TargetPort: test.PortStr2, // ignored
+					Protocol:   test.Protocol1,
+				},
+			},
+			want: v1alpha1.ServicePort{
+				Name:     test.PortName1,
+				Protocol: v1.ProtocolTCP,
+				Port:     test.Port1,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PortToServiceImportPort(tt.args.port); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("PortToServiceImportPort() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestPortToEndpointPort(t *testing.T) {
 	name := "http"
 	protocolTCP := v1.ProtocolTCP
@@ -178,6 +250,241 @@ func TestPortToEndpointPort(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := PortToEndpointPort(tt.args.port); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("PortToEndpointPort() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractServicePorts(t *testing.T) {
+	type args struct {
+		endpoints []*model.Endpoint
+	}
+	tests := []struct {
+		name string
+		args args
+		want []*model.Port
+	}{
+		{
+			name: "unique service ports extracted",
+			args: args{
+				endpoints: []*model.Endpoint{
+					{
+						ServicePort: model.Port{Protocol: test.Protocol1, Port: test.Port1},
+					},
+					{
+						ServicePort: model.Port{Protocol: test.Protocol1, Port: test.Port2},
+					},
+					{
+						ServicePort: model.Port{Protocol: test.Protocol2, Port: test.Port2},
+					},
+				},
+			},
+			want: []*model.Port{
+				{Protocol: test.Protocol1, Port: test.Port1},
+				{Protocol: test.Protocol1, Port: test.Port2},
+				{Protocol: test.Protocol2, Port: test.Port2},
+			},
+		},
+		{
+			name: "duplicate and endpoint ports ignored",
+			args: args{
+				endpoints: []*model.Endpoint{
+					{
+						ServicePort:  model.Port{Protocol: test.Protocol1, Port: test.Port1},
+						EndpointPort: model.Port{Protocol: test.Protocol1, Port: test.Port1},
+					},
+					{
+						ServicePort:  model.Port{Protocol: test.Protocol1, Port: test.Port1},
+						EndpointPort: model.Port{Protocol: test.Protocol2, Port: test.Port2},
+					},
+				},
+			},
+			want: []*model.Port{
+				{Protocol: test.Protocol1, Port: test.Port1},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtractServicePorts(tt.args.endpoints); !PortsEqualIgnoreOrder(got, tt.want) {
+				t.Errorf("ServicePortToPort() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractEndpointPorts(t *testing.T) {
+	type args struct {
+		endpoints []*model.Endpoint
+	}
+	tests := []struct {
+		name string
+		args args
+		want []*model.Port
+	}{
+		{
+			name: "unique endpoint ports extracted",
+			args: args{
+				endpoints: []*model.Endpoint{
+					{
+						EndpointPort: model.Port{Protocol: test.Protocol1, Port: test.Port1},
+					},
+					{
+						EndpointPort: model.Port{Protocol: test.Protocol1, Port: test.Port2},
+					},
+					{
+						EndpointPort: model.Port{Protocol: test.Protocol2, Port: test.Port2},
+					},
+				},
+			},
+			want: []*model.Port{
+				{Protocol: test.Protocol1, Port: test.Port1},
+				{Protocol: test.Protocol1, Port: test.Port2},
+				{Protocol: test.Protocol2, Port: test.Port2},
+			},
+		},
+		{
+			name: "duplicate and service ports ignored",
+			args: args{
+				endpoints: []*model.Endpoint{
+					{
+						EndpointPort: model.Port{Protocol: test.Protocol1, Port: test.Port1},
+						ServicePort:  model.Port{Protocol: test.Protocol1, Port: test.Port1},
+					},
+					{
+						EndpointPort: model.Port{Protocol: test.Protocol1, Port: test.Port1},
+						ServicePort:  model.Port{Protocol: test.Protocol2, Port: test.Port2},
+					},
+				},
+			},
+			want: []*model.Port{
+				{Protocol: test.Protocol1, Port: test.Port1},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtractEndpointPorts(tt.args.endpoints); !PortsEqualIgnoreOrder(got, tt.want) {
+				t.Errorf("ServicePortToPort() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPortsEqualIgnoreOrder(t *testing.T) {
+	type args struct {
+		portsA []*model.Port
+		portsB []*model.Port
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "ports equal same order",
+			args: args{
+				portsA: []*model.Port{
+					{Protocol: test.Protocol1, Port: test.Port1},
+					{Protocol: test.Protocol2, Port: test.Port2},
+				},
+				portsB: []*model.Port{
+					{Protocol: test.Protocol1, Port: test.Port1},
+					{Protocol: test.Protocol2, Port: test.Port2},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "ports equal different order",
+			args: args{
+				portsA: []*model.Port{
+					{Protocol: test.Protocol1, Port: test.Port1},
+					{Protocol: test.Protocol2, Port: test.Port2},
+				},
+				portsB: []*model.Port{
+					{Protocol: test.Protocol2, Port: test.Port2},
+					{Protocol: test.Protocol1, Port: test.Port1},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "ports not equal",
+			args: args{
+				portsA: []*model.Port{
+					{Protocol: test.Protocol1, Port: test.Port1},
+					{Protocol: test.Protocol2, Port: test.Port2},
+				},
+				portsB: []*model.Port{
+					{Protocol: test.Protocol1, Port: test.Port1},
+					{Protocol: test.Protocol2, Port: 3},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "protocols not equal",
+			args: args{
+				portsA: []*model.Port{
+					{Protocol: test.Protocol1, Port: test.Port1},
+					{Protocol: test.Protocol2, Port: test.Port2},
+				},
+				portsB: []*model.Port{
+					{Protocol: test.Protocol1, Port: test.Port1},
+					{Protocol: test.Protocol1, Port: test.Port2},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PortsEqualIgnoreOrder(tt.args.portsA, tt.args.portsB); !(got == tt.want) {
+				t.Errorf("PortsEqualIgnoreOrder() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateServiceImportStruct(t *testing.T) {
+	type args struct {
+		servicePorts []*model.Port
+	}
+	tests := []struct {
+		name string
+		args args
+		want v1alpha1.ServiceImport
+	}{
+		{
+			name: "happy case",
+			args: args{
+				servicePorts: []*model.Port{
+					{Name: test.PortName1, Protocol: test.Protocol1, Port: test.Port1},
+					{Name: test.PortName2, Protocol: test.Protocol1, Port: test.Port2},
+				},
+			},
+			want: v1alpha1.ServiceImport{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   test.NsName,
+					Name:        test.SvcName,
+					Annotations: map[string]string{DerivedServiceAnnotation: DerivedName(test.NsName, test.SvcName)},
+				},
+				Spec: v1alpha1.ServiceImportSpec{
+					IPs:  []string{},
+					Type: v1alpha1.ClusterSetIP,
+					Ports: []v1alpha1.ServicePort{
+						{Name: test.PortName1, Protocol: v1.ProtocolTCP, Port: test.Port1},
+						{Name: test.PortName2, Protocol: v1.ProtocolTCP, Port: test.Port2},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CreateServiceImportStruct(test.NsName, test.SvcName, tt.args.servicePorts); !reflect.DeepEqual(*got, tt.want) {
+				t.Errorf("CreateServiceImportStruct() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -66,9 +66,6 @@ const (
 	ServicePortAttr       = "SERVICE_PORT"
 	ServiceTargetPortAttr = "SERVICE_TARGET_PORT"
 	ServiceProtocolAttr   = "SERVICE_PROTOCOL"
-	TCPProtocol           = "TCP"
-	UDPProtocol           = "UDP"
-	SCTPProtocol          = "SCTP"
 )
 
 // NewEndpointFromInstance converts a Cloud Map HttpInstanceSummary to an endpoint.
@@ -210,6 +207,11 @@ func (namespaceType *NamespaceType) IsUnsupported() bool {
 	return *namespaceType == UnsupportedNamespaceType
 }
 
-func (port *Port) GetID() string {
-	return fmt.Sprintf("%s:%d", port.Protocol, port.Port)
+func (p *Port) GetID() string {
+	return fmt.Sprintf("%s:%d", p.Protocol, p.Port)
+}
+
+// Equals evaluates if two Ports are "deeply equal" (including all fields).
+func (p *Port) Equals(other *Port) bool {
+	return reflect.DeepEqual(p, other)
 }

--- a/test/test-constants.go
+++ b/test/test-constants.go
@@ -1,6 +1,8 @@
 package test
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
 )
 
@@ -22,7 +24,7 @@ const (
 	Port2           = 2
 	PortStr2        = "2"
 	PortName2       = "http"
-	Protocol2       = "TCP"
+	Protocol2       = "UDP"
 	ServicePort2    = 22
 	ServicePortStr2 = "22"
 	OpId1           = "operation-id-1"
@@ -98,4 +100,15 @@ func GetTestEndpoint2() *model.Endpoint {
 		},
 		Attributes: make(map[string]string),
 	}
+}
+
+func GetTestEndpoints(count int) (endpts []*model.Endpoint) {
+	// use +3 offset go avoid collision with test endpoint 1 and 2
+	for i := 3; i < count+3; i++ {
+		e := GetTestEndpoint1()
+		e.Id = fmt.Sprintf("tcp-192_168_0_%d-1", i)
+		e.IP = fmt.Sprintf("192.168.0.%d", i)
+		endpts = append(endpts, e)
+	}
+	return endpts
 }


### PR DESCRIPTION
*Issue #, if available:*
#101 

*Description of changes:*
Multiple improvements to service import logic.
* EndpointSlice change plan calculates necessary changes for endpoints.
* Derived service ports are updated based on imported external changes.
* Internal Port model is simplified and used broadly for comparisons ignoring order.
* Constructor logic moved to util class
* Some common test struct factory logic moved to controllers_common_test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
