### PR TITLE
Move mocks to mock packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,14 +134,14 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 
 MOCKS_DESTINATION=mocks
 generate-mocks: mockgen
-	$(MOCKGEN) --source pkg/cloudmap/client.go --destination $(MOCKS_DESTINATION)/pkg/cloudmap/client_mock.go --package cloudmap
-	$(MOCKGEN) --source pkg/cloudmap/cache.go --destination $(MOCKS_DESTINATION)/pkg/cloudmap/cache_mock.go --package cloudmap
-	$(MOCKGEN) --source pkg/cloudmap/operation_poller.go --destination $(MOCKS_DESTINATION)/pkg/cloudmap/operation_poller_mock.go --package cloudmap
-	$(MOCKGEN) --source pkg/cloudmap/operation_collector.go --destination $(MOCKS_DESTINATION)/pkg/cloudmap/operation_collector_mock.go --package cloudmap
-	$(MOCKGEN) --source pkg/cloudmap/api.go --destination $(MOCKS_DESTINATION)/pkg/cloudmap/api_mock.go --package cloudmap
-	$(MOCKGEN) --source pkg/cloudmap/aws_facade.go --destination $(MOCKS_DESTINATION)/pkg/cloudmap/aws_facade_mock.go --package cloudmap
-	$(MOCKGEN) --source integration/janitor/api.go --destination $(MOCKS_DESTINATION)/integration/janitor/api_mock.go --package janitor
-	$(MOCKGEN) --source integration/janitor/aws_facade.go --destination $(MOCKS_DESTINATION)/integration/janitor/aws_facade_mock.go --package janitor
+	$(MOCKGEN) --source pkg/cloudmap/client.go --destination $(MOCKS_DESTINATION)/pkg/cloudmap/client_mock.go --package cloudmap_mock
+	$(MOCKGEN) --source pkg/cloudmap/cache.go --destination $(MOCKS_DESTINATION)/pkg/cloudmap/cache_mock.go --package cloudmap_mock
+	$(MOCKGEN) --source pkg/cloudmap/operation_poller.go --destination $(MOCKS_DESTINATION)/pkg/cloudmap/operation_poller_mock.go --package cloudmap_mock
+	$(MOCKGEN) --source pkg/cloudmap/operation_collector.go --destination $(MOCKS_DESTINATION)/pkg/cloudmap/operation_collector_mock.go --package cloudmap_mock
+	$(MOCKGEN) --source pkg/cloudmap/api.go --destination $(MOCKS_DESTINATION)/pkg/cloudmap/api_mock.go --package cloudmap_mock
+	$(MOCKGEN) --source pkg/cloudmap/aws_facade.go --destination $(MOCKS_DESTINATION)/pkg/cloudmap/aws_facade_mock.go --package cloudmap_mock
+	$(MOCKGEN) --source integration/janitor/api.go --destination $(MOCKS_DESTINATION)/integration/janitor/api_mock.go --package janitor_mock
+	$(MOCKGEN) --source integration/janitor/aws_facade.go --destination $(MOCKS_DESTINATION)/integration/janitor/aws_facade_mock.go --package janitor_mock
 
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen

--- a/integration/janitor/api_test.go
+++ b/integration/janitor/api_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/mocks/integration/janitor"
+	janitorMock "github.com/aws/aws-cloud-map-mcs-controller-for-k8s/mocks/integration/janitor"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/test"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	sd "github.com/aws/aws-sdk-go-v2/service/servicediscovery"
@@ -20,7 +20,7 @@ func TestServiceDiscoveryJanitorApi_DeleteNamespace_HappyCase(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	mocksdk := janitor.NewMockSdkJanitorFacade(mockController)
+	mocksdk := janitorMock.NewMockSdkJanitorFacade(mockController)
 	jApi := getJanitorApi(mocksdk)
 
 	mocksdk.EXPECT().DeleteNamespace(context.TODO(), &sd.DeleteNamespaceInput{Id: aws.String(test.NsId)}).
@@ -35,7 +35,7 @@ func TestServiceDiscoveryJanitorApi_DeleteService_HappyCase(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	mocksdk := janitor.NewMockSdkJanitorFacade(mockController)
+	mocksdk := janitorMock.NewMockSdkJanitorFacade(mockController)
 	jApi := getJanitorApi(mocksdk)
 
 	mocksdk.EXPECT().DeleteService(context.TODO(), &sd.DeleteServiceInput{Id: aws.String(test.SvcId)}).
@@ -45,7 +45,7 @@ func TestServiceDiscoveryJanitorApi_DeleteService_HappyCase(t *testing.T) {
 	assert.Nil(t, err, "No error for happy case")
 }
 
-func getJanitorApi(sdk *janitor.MockSdkJanitorFacade) ServiceDiscoveryJanitorApi {
+func getJanitorApi(sdk *janitorMock.MockSdkJanitorFacade) ServiceDiscoveryJanitorApi {
 	return &serviceDiscoveryJanitorApi{
 		janitorFacade: sdk,
 	}

--- a/integration/janitor/janitor_test.go
+++ b/integration/janitor/janitor_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/mocks/integration/janitor"
+	janitorMock "github.com/aws/aws-cloud-map-mcs-controller-for-k8s/mocks/integration/janitor"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/test"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -15,7 +15,7 @@ import (
 
 type testJanitor struct {
 	janitor *cloudMapJanitor
-	mockApi *janitor.MockServiceDiscoveryJanitorApi
+	mockApi *janitorMock.MockServiceDiscoveryJanitorApi
 	failed  *bool
 	close   func()
 }
@@ -63,7 +63,7 @@ func TestCleanupNothingToClean(t *testing.T) {
 
 func getTestJanitor(t *testing.T) *testJanitor {
 	mockController := gomock.NewController(t)
-	api := janitor.NewMockServiceDiscoveryJanitorApi(mockController)
+	api := janitorMock.NewMockServiceDiscoveryJanitorApi(mockController)
 	failed := false
 	return &testJanitor{
 		janitor: &cloudMapJanitor{

--- a/pkg/cloudmap/api_test.go
+++ b/pkg/cloudmap/api_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/mocks/pkg/cloudmap"
+	cloudmapMock "github.com/aws/aws-cloud-map-mcs-controller-for-k8s/mocks/pkg/cloudmap"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/common"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/test"
@@ -27,7 +27,7 @@ func TestServiceDiscoveryApi_ListNamespaces_HappyCase(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	awsFacade := cloudmap.NewMockAwsFacade(mockController)
+	awsFacade := cloudmapMock.NewMockAwsFacade(mockController)
 	sdApi := getServiceDiscoveryApi(t, awsFacade)
 
 	id, name := test.NsId, test.NsName
@@ -48,7 +48,7 @@ func TestServiceDiscoveryApi_ListNamespaces_SkipPublicDNSNotSupported(t *testing
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	awsFacade := cloudmap.NewMockAwsFacade(mockController)
+	awsFacade := cloudmapMock.NewMockAwsFacade(mockController)
 	sdApi := getServiceDiscoveryApi(t, awsFacade)
 
 	id, name := test.NsId, test.NsName
@@ -68,7 +68,7 @@ func TestServiceDiscoveryApi_ListServices_HappyCase(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	awsFacade := cloudmap.NewMockAwsFacade(mockController)
+	awsFacade := cloudmapMock.NewMockAwsFacade(mockController)
 	sdApi := getServiceDiscoveryApi(t, awsFacade)
 
 	filter := types.ServiceFilter{
@@ -91,7 +91,7 @@ func TestServiceDiscoveryApi_DiscoverInstances_HappyCase(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	awsFacade := cloudmap.NewMockAwsFacade(mockController)
+	awsFacade := cloudmapMock.NewMockAwsFacade(mockController)
 	sdApi := getServiceDiscoveryApi(t, awsFacade)
 
 	awsFacade.EXPECT().DiscoverInstances(context.TODO(),
@@ -119,7 +119,7 @@ func TestServiceDiscoveryApi_ListOperations_HappyCase(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	awsFacade := cloudmap.NewMockAwsFacade(mockController)
+	awsFacade := cloudmapMock.NewMockAwsFacade(mockController)
 	sdApi := getServiceDiscoveryApi(t, awsFacade)
 
 	filters := make([]types.OperationFilter, 0)
@@ -139,7 +139,7 @@ func TestServiceDiscoveryApi_GetOperation_HappyCase(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	awsFacade := cloudmap.NewMockAwsFacade(mockController)
+	awsFacade := cloudmapMock.NewMockAwsFacade(mockController)
 	sdApi := getServiceDiscoveryApi(t, awsFacade)
 
 	expectedOp := &types.Operation{Id: aws.String(test.OpId1), Status: types.OperationStatusPending}
@@ -155,7 +155,7 @@ func TestServiceDiscoveryApi_CreateHttNamespace_HappyCase(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	awsFacade := cloudmap.NewMockAwsFacade(mockController)
+	awsFacade := cloudmapMock.NewMockAwsFacade(mockController)
 	sdApi := getServiceDiscoveryApi(t, awsFacade)
 
 	awsFacade.EXPECT().CreateHttpNamespace(context.TODO(), &sd.CreateHttpNamespaceInput{Name: aws.String(test.NsName)}).
@@ -170,7 +170,7 @@ func TestServiceDiscoveryApi_CreateService_CreateForHttpNamespace(t *testing.T) 
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	awsFacade := cloudmap.NewMockAwsFacade(mockController)
+	awsFacade := cloudmapMock.NewMockAwsFacade(mockController)
 	sdApi := getServiceDiscoveryApi(t, awsFacade)
 
 	nsId, svcId, svcName := test.NsId, test.SvcId, test.SvcName
@@ -192,7 +192,7 @@ func TestServiceDiscoveryApi_CreateService_CreateForDnsNamespace(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	awsFacade := cloudmap.NewMockAwsFacade(mockController)
+	awsFacade := cloudmapMock.NewMockAwsFacade(mockController)
 	sdApi := getServiceDiscoveryApi(t, awsFacade)
 
 	nsId, svcId, svcName := test.NsId, test.SvcId, test.SvcName
@@ -220,7 +220,7 @@ func TestServiceDiscoveryApi_CreateService_ThrowError(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	awsFacade := cloudmap.NewMockAwsFacade(mockController)
+	awsFacade := cloudmapMock.NewMockAwsFacade(mockController)
 	sdApi := getServiceDiscoveryApi(t, awsFacade)
 
 	nsId, svcName := test.NsId, test.SvcName
@@ -241,7 +241,7 @@ func TestServiceDiscoveryApi_RegisterInstance_HappyCase(t *testing.T) {
 
 	attrs := map[string]string{"a": "b"}
 
-	awsFacade := cloudmap.NewMockAwsFacade(mockController)
+	awsFacade := cloudmapMock.NewMockAwsFacade(mockController)
 	awsFacade.EXPECT().RegisterInstance(context.TODO(),
 		&sd.RegisterInstanceInput{
 			ServiceId:  aws.String(test.SvcId),
@@ -260,7 +260,7 @@ func TestServiceDiscoveryApi_RegisterInstance_Error(t *testing.T) {
 	defer mockController.Finish()
 
 	sdkErr := errors.New("fail")
-	awsFacade := cloudmap.NewMockAwsFacade(mockController)
+	awsFacade := cloudmapMock.NewMockAwsFacade(mockController)
 	awsFacade.EXPECT().RegisterInstance(context.TODO(), gomock.Any()).Return(nil, sdkErr)
 
 	sdApi := getServiceDiscoveryApi(t, awsFacade)
@@ -272,7 +272,7 @@ func TestServiceDiscoveryApi_DeregisterInstance_HappyCase(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	awsFacade := cloudmap.NewMockAwsFacade(mockController)
+	awsFacade := cloudmapMock.NewMockAwsFacade(mockController)
 	awsFacade.EXPECT().DeregisterInstance(context.TODO(),
 		&sd.DeregisterInstanceInput{
 			ServiceId:  aws.String(test.SvcId),
@@ -290,7 +290,7 @@ func TestServiceDiscoveryApi_DeregisterInstance_Error(t *testing.T) {
 	defer mockController.Finish()
 
 	sdkErr := errors.New("fail")
-	awsFacade := cloudmap.NewMockAwsFacade(mockController)
+	awsFacade := cloudmapMock.NewMockAwsFacade(mockController)
 	awsFacade.EXPECT().DeregisterInstance(context.TODO(), gomock.Any()).Return(nil, sdkErr)
 
 	sdApi := getServiceDiscoveryApi(t, awsFacade)
@@ -302,7 +302,7 @@ func TestServiceDiscoveryApi_PollNamespaceOperation_HappyCase(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	awsFacade := cloudmap.NewMockAwsFacade(mockController)
+	awsFacade := cloudmapMock.NewMockAwsFacade(mockController)
 	awsFacade.EXPECT().GetOperation(context.TODO(), &sd.GetOperationInput{OperationId: aws.String(test.OpId1)}).
 		Return(&sd.GetOperationOutput{Operation: &types.Operation{Status: types.OperationStatusPending}}, nil)
 
@@ -317,7 +317,7 @@ func TestServiceDiscoveryApi_PollNamespaceOperation_HappyCase(t *testing.T) {
 	assert.Equal(t, test.NsId, nsId)
 }
 
-func getServiceDiscoveryApi(t *testing.T, awsFacade *cloudmap.MockAwsFacade) ServiceDiscoveryApi {
+func getServiceDiscoveryApi(t *testing.T, awsFacade *cloudmapMock.MockAwsFacade) ServiceDiscoveryApi {
 	return &serviceDiscoveryApi{
 		log:       common.NewLoggerWithLogr(testingLogger.TestLogger{T: t}),
 		awsFacade: awsFacade,

--- a/pkg/cloudmap/client_test.go
+++ b/pkg/cloudmap/client_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/mocks/pkg/cloudmap"
+	cloudmapMock "github.com/aws/aws-cloud-map-mcs-controller-for-k8s/mocks/pkg/cloudmap"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/common"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/test"
@@ -18,8 +18,8 @@ import (
 
 type testSdClient struct {
 	client    *serviceDiscoveryClient
-	mockApi   cloudmap.MockServiceDiscoveryApi
-	mockCache cloudmap.MockServiceDiscoveryClientCache
+	mockApi   cloudmapMock.MockServiceDiscoveryApi
+	mockCache cloudmapMock.MockServiceDiscoveryClientCache
 	close     func()
 }
 
@@ -354,8 +354,8 @@ func TestServiceDiscoveryClient_DeleteEndpoints(t *testing.T) {
 
 func getTestSdClient(t *testing.T) *testSdClient {
 	mockController := gomock.NewController(t)
-	mockCache := cloudmap.NewMockServiceDiscoveryClientCache(mockController)
-	mockApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
+	mockCache := cloudmapMock.NewMockServiceDiscoveryClientCache(mockController)
+	mockApi := cloudmapMock.NewMockServiceDiscoveryApi(mockController)
 	return &testSdClient{
 		client: &serviceDiscoveryClient{
 			log:   common.NewLoggerWithLogr(testing2.TestLogger{T: t}),

--- a/pkg/cloudmap/operation_poller_test.go
+++ b/pkg/cloudmap/operation_poller_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/mocks/pkg/cloudmap"
+	cloudmapMock "github.com/aws/aws-cloud-map-mcs-controller-for-k8s/mocks/pkg/cloudmap"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/common"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/test"
 	"github.com/aws/aws-sdk-go-v2/service/servicediscovery/types"
@@ -20,7 +20,7 @@ func TestOperationPoller_HappyCases(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
+	sdApi := cloudmapMock.NewMockServiceDiscoveryApi(mockController)
 
 	pollerTypes := []struct {
 		constructor    func() OperationPoller
@@ -105,7 +105,7 @@ func TestOperationPoller_PollEmpty(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
+	sdApi := cloudmapMock.NewMockServiceDiscoveryApi(mockController)
 
 	p := NewRegisterInstancePoller(sdApi, test.SvcId, []string{}, test.OpStart)
 	err := p.Poll(context.TODO())
@@ -116,7 +116,7 @@ func TestOperationPoller_PollFailure(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
+	sdApi := cloudmapMock.NewMockServiceDiscoveryApi(mockController)
 
 	p := NewRegisterInstancePoller(sdApi, test.SvcId, []string{test.OpId1, test.OpId2}, test.OpStart)
 
@@ -134,7 +134,7 @@ func TestOperationPoller_PollOpFailure(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
+	sdApi := cloudmapMock.NewMockServiceDiscoveryApi(mockController)
 
 	p := NewRegisterInstancePoller(sdApi, test.SvcId, []string{test.OpId1, test.OpId2}, test.OpStart)
 
@@ -160,7 +160,7 @@ func TestOperationPoller_PollOpFailureAndMessageFailure(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
+	sdApi := cloudmapMock.NewMockServiceDiscoveryApi(mockController)
 
 	p := NewRegisterInstancePoller(sdApi, test.SvcId, []string{test.OpId1, test.OpId2}, test.OpStart)
 
@@ -184,7 +184,7 @@ func TestOperationPoller_PollTimeout(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	sdApi := cloudmap.NewMockServiceDiscoveryApi(mockController)
+	sdApi := cloudmapMock.NewMockServiceDiscoveryApi(mockController)
 
 	p := operationPoller{
 		log:     common.NewLoggerWithLogr(testing2.TestLogger{T: t}),

--- a/pkg/controllers/cloudmap_controller_test.go
+++ b/pkg/controllers/cloudmap_controller_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/mocks/pkg/cloudmap"
+	cloudmapMock "github.com/aws/aws-cloud-map-mcs-controller-for-k8s/mocks/pkg/cloudmap"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/api/v1alpha1"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/common"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
@@ -35,7 +35,7 @@ func TestCloudMapReconciler_Reconcile(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	mockSDClient := cloudmap.NewMockServiceDiscoveryClient(mockController)
+	mockSDClient := cloudmapMock.NewMockServiceDiscoveryClient(mockController)
 	// The service model in the Cloudmap
 	mockSDClient.EXPECT().ListServices(context.TODO(), test.NsName).
 		Return([]*model.Service{test.GetTestServiceWithEndpoint([]*model.Endpoint{test.GetTestEndpoint1()})}, nil)
@@ -72,7 +72,7 @@ func TestCloudMapReconciler_Reconcile(t *testing.T) {
 	assert.Equal(t, test.EndptIp1, endpointSlice.Endpoints[0].Addresses[0])
 }
 
-func getReconciler(t *testing.T, mockSDClient *cloudmap.MockServiceDiscoveryClient, client client.Client) *CloudMapReconciler {
+func getReconciler(t *testing.T, mockSDClient *cloudmapMock.MockServiceDiscoveryClient, client client.Client) *CloudMapReconciler {
 	return &CloudMapReconciler{
 		Client:   client,
 		Cloudmap: mockSDClient,

--- a/pkg/controllers/serviceexport_controller_test.go
+++ b/pkg/controllers/serviceexport_controller_test.go
@@ -3,7 +3,7 @@ package controllers
 import (
 	"context"
 
-	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/mocks/pkg/cloudmap"
+	cloudmapMock "github.com/aws/aws-cloud-map-mcs-controller-for-k8s/mocks/pkg/cloudmap"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/api/v1alpha1"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/common"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
@@ -37,7 +37,7 @@ func TestServiceExportReconciler_Reconcile_NewServiceExport(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	mock := cloudmap.NewMockServiceDiscoveryClient(mockController)
+	mock := cloudmapMock.NewMockServiceDiscoveryClient(mockController)
 	// expected interactions with the Cloud Map client
 	// The first get call is expected to return nil, then second call after the creation of service is
 	// supposed to return the value
@@ -84,7 +84,7 @@ func TestServiceExportReconciler_Reconcile_ExistingServiceExport(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	mock := cloudmap.NewMockServiceDiscoveryClient(mockController)
+	mock := cloudmapMock.NewMockServiceDiscoveryClient(mockController)
 
 	// GetService from Cloudmap returns endpoint1 and endpoint2
 	mock.EXPECT().GetService(gomock.Any(), test.NsName, test.SvcName).
@@ -131,7 +131,7 @@ func TestServiceExportReconciler_Reconcile_DeleteExistingService(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	mock := cloudmap.NewMockServiceDiscoveryClient(mockController)
+	mock := cloudmapMock.NewMockServiceDiscoveryClient(mockController)
 
 	// GetService from Cloudmap returns endpoint1 and endpoint2
 	mock.EXPECT().GetService(gomock.Any(), test.NsName, test.SvcName).
@@ -167,7 +167,7 @@ func getServiceExportScheme() *runtime.Scheme {
 	return scheme
 }
 
-func getServiceExportReconciler(t *testing.T, mockClient *cloudmap.MockServiceDiscoveryClient, client client.Client) *ServiceExportReconciler {
+func getServiceExportReconciler(t *testing.T, mockClient *cloudmapMock.MockServiceDiscoveryClient, client client.Client) *ServiceExportReconciler {
 	return &ServiceExportReconciler{
 		Client:   client,
 		Log:      common.NewLoggerWithLogr(testing2.TestLogger{T: t}),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Prevent cyclical imports in mocks by moving them to new `_mock` packages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
