### PR TITLE
Cache namespace and service maps

### DIFF
--- a/integration/janitor/api_test.go
+++ b/integration/janitor/api_test.go
@@ -23,10 +23,10 @@ func TestServiceDiscoveryJanitorApi_DeleteNamespace_HappyCase(t *testing.T) {
 	mocksdk := janitorMock.NewMockSdkJanitorFacade(mockController)
 	jApi := getJanitorApi(mocksdk)
 
-	mocksdk.EXPECT().DeleteNamespace(context.TODO(), &sd.DeleteNamespaceInput{Id: aws.String(test.NsId)}).
+	mocksdk.EXPECT().DeleteNamespace(context.TODO(), &sd.DeleteNamespaceInput{Id: aws.String(test.HttpNsId)}).
 		Return(&sd.DeleteNamespaceOutput{OperationId: aws.String(test.OpId1)}, nil)
 
-	opId, err := jApi.DeleteNamespace(context.TODO(), test.NsId)
+	opId, err := jApi.DeleteNamespace(context.TODO(), test.HttpNsId)
 	assert.Nil(t, err, "No error for happy case")
 	assert.Equal(t, test.OpId1, opId)
 }

--- a/pkg/cloudmap/client_test.go
+++ b/pkg/cloudmap/client_test.go
@@ -2,7 +2,6 @@ package cloudmap
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	cloudmapMock "github.com/aws/aws-cloud-map-mcs-controller-for-k8s/mocks/pkg/cloudmap"
@@ -13,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/servicediscovery/types"
 	testing2 "github.com/go-logr/logr/testing"
 	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,22 +32,22 @@ func TestServiceDiscoveryClient_ListServices_HappyCase(t *testing.T) {
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(nil, false)
-	tc.mockApi.EXPECT().ListNamespaces(context.TODO()).
-		Return([]*model.Namespace{test.GetTestHttpNamespace()}, nil)
-	tc.mockCache.EXPECT().CacheNamespace(test.GetTestHttpNamespace())
+	tc.mockCache.EXPECT().GetServiceIdMap(test.HttpNsName).Return(nil, false)
 
-	tc.mockApi.EXPECT().ListServices(context.TODO(), test.NsId).
-		Return([]*model.Resource{{Name: test.SvcName, Id: test.SvcId}}, nil)
-	tc.mockCache.EXPECT().CacheServiceId(test.NsName, test.SvcName, test.SvcId)
+	tc.mockCache.EXPECT().GetNamespaceMap().Return(nil, false)
+	tc.mockApi.EXPECT().GetNamespaceMap(context.TODO()).Return(getNamespaceMapForTest(), nil)
+	tc.mockCache.EXPECT().CacheNamespaceMap(getNamespaceMapForTest())
 
-	tc.mockCache.EXPECT().GetEndpoints(test.NsName, test.SvcName).Return(nil, false)
-	tc.mockApi.EXPECT().DiscoverInstances(context.TODO(), test.NsName, test.SvcName).
-		Return(testHttpInstanceSummary(), nil)
-	tc.mockCache.EXPECT().CacheEndpoints(test.NsName, test.SvcName,
+	tc.mockApi.EXPECT().GetServiceIdMap(context.TODO(), test.HttpNsId).Return(getServiceIdMapForTest(), nil)
+	tc.mockCache.EXPECT().CacheServiceIdMap(test.HttpNsName, getServiceIdMapForTest())
+
+	tc.mockCache.EXPECT().GetEndpoints(test.HttpNsName, test.SvcName).Return(nil, false)
+	tc.mockApi.EXPECT().DiscoverInstances(context.TODO(), test.HttpNsName, test.SvcName).
+		Return(getHttpInstanceSummaryForTest(), nil)
+	tc.mockCache.EXPECT().CacheEndpoints(test.HttpNsName, test.SvcName,
 		[]*model.Endpoint{test.GetTestEndpoint1(), test.GetTestEndpoint2()})
 
-	svcs, err := tc.client.ListServices(context.TODO(), test.NsName)
+	svcs, err := tc.client.ListServices(context.TODO(), test.HttpNsName)
 	assert.Equal(t, []*model.Service{test.GetTestService()}, svcs)
 	assert.Nil(t, err, "No error for happy case")
 }
@@ -56,17 +56,16 @@ func TestServiceDiscoveryClient_ListServices_HappyCaseCachedResults(t *testing.T
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(test.GetTestHttpNamespace(), true)
+	dnsService := test.GetTestService()
+	dnsService.Namespace = test.DnsNsName
 
-	tc.mockApi.EXPECT().ListServices(context.TODO(), test.NsId).
-		Return([]*model.Resource{{Name: test.SvcName, Id: test.SvcId}}, nil)
-	tc.mockCache.EXPECT().CacheServiceId(test.NsName, test.SvcName, test.SvcId)
+	tc.mockCache.EXPECT().GetServiceIdMap(test.DnsNsName).Return(getServiceIdMapForTest(), true)
 
-	tc.mockCache.EXPECT().GetEndpoints(test.NsName, test.SvcName).
+	tc.mockCache.EXPECT().GetEndpoints(test.DnsNsName, test.SvcName).
 		Return([]*model.Endpoint{test.GetTestEndpoint1(), test.GetTestEndpoint2()}, true)
 
-	svcs, err := tc.client.ListServices(context.TODO(), test.NsName)
-	assert.Equal(t, []*model.Service{test.GetTestService()}, svcs)
+	svcs, err := tc.client.ListServices(context.TODO(), test.DnsNsName)
+	assert.Equal(t, []*model.Service{dnsService}, svcs)
 	assert.Nil(t, err, "No error for happy case")
 }
 
@@ -74,12 +73,13 @@ func TestServiceDiscoveryClient_ListServices_NamespaceError(t *testing.T) {
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	nsErr := errors.New("error listing namespaces")
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(nil, false)
-	tc.mockApi.EXPECT().ListNamespaces(context.TODO()).
-		Return(nil, nsErr)
+	tc.mockCache.EXPECT().GetServiceIdMap(test.HttpNsName).Return(nil, false)
 
-	svcs, err := tc.client.ListServices(context.TODO(), test.NsName)
+	nsErr := errors.New("error listing namespaces")
+	tc.mockCache.EXPECT().GetNamespaceMap().Return(nil, false)
+	tc.mockApi.EXPECT().GetNamespaceMap(context.TODO()).Return(nil, nsErr)
+
+	svcs, err := tc.client.ListServices(context.TODO(), test.HttpNsName)
 	assert.Equal(t, nsErr, err)
 	assert.Empty(t, svcs)
 }
@@ -88,13 +88,15 @@ func TestServiceDiscoveryClient_ListServices_ServiceError(t *testing.T) {
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(test.GetTestHttpNamespace(), true)
+	tc.mockCache.EXPECT().GetServiceIdMap(test.HttpNsName).Return(nil, false)
+
+	tc.mockCache.EXPECT().GetNamespaceMap().Return(getNamespaceMapForTest(), true)
 
 	svcErr := errors.New("error listing services")
-	tc.mockApi.EXPECT().ListServices(context.TODO(), test.NsId).
-		Return([]*model.Resource{}, svcErr)
+	tc.mockApi.EXPECT().GetServiceIdMap(context.TODO(), test.HttpNsId).
+		Return(nil, svcErr)
 
-	svcs, err := tc.client.ListServices(context.TODO(), test.NsName)
+	svcs, err := tc.client.ListServices(context.TODO(), test.HttpNsName)
 	assert.Equal(t, svcErr, err)
 	assert.Empty(t, svcs)
 }
@@ -103,18 +105,14 @@ func TestServiceDiscoveryClient_ListServices_InstanceError(t *testing.T) {
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(test.GetTestHttpNamespace(), true)
-
-	tc.mockApi.EXPECT().ListServices(context.TODO(), test.NsId).
-		Return([]*model.Resource{{Name: test.SvcName, Id: test.SvcId}}, nil)
-	tc.mockCache.EXPECT().CacheServiceId(test.NsName, test.SvcName, test.SvcId)
+	tc.mockCache.EXPECT().GetServiceIdMap(test.HttpNsName).Return(getServiceIdMapForTest(), true)
 
 	endptErr := errors.New("error listing endpoints")
-	tc.mockCache.EXPECT().GetEndpoints(test.NsName, test.SvcName).Return(nil, false)
-	tc.mockApi.EXPECT().DiscoverInstances(context.TODO(), test.NsName, test.SvcName).
+	tc.mockCache.EXPECT().GetEndpoints(test.HttpNsName, test.SvcName).Return(nil, false)
+	tc.mockApi.EXPECT().DiscoverInstances(context.TODO(), test.HttpNsName, test.SvcName).
 		Return([]types.HttpInstanceSummary{}, endptErr)
 
-	svcs, err := tc.client.ListServices(context.TODO(), test.NsName)
+	svcs, err := tc.client.ListServices(context.TODO(), test.HttpNsName)
 	assert.Equal(t, endptErr, err)
 	assert.Empty(t, svcs)
 }
@@ -123,12 +121,10 @@ func TestServiceDiscoveryClient_ListServices_NamespaceNotFound(t *testing.T) {
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(nil, false)
-	tc.mockApi.EXPECT().ListNamespaces(context.TODO()).
-		Return([]*model.Namespace{}, nil)
-	tc.mockCache.EXPECT().CacheNilNamespace(test.NsName)
+	tc.mockCache.EXPECT().GetServiceIdMap(test.HttpNsName).Return(nil, false)
+	tc.mockCache.EXPECT().GetNamespaceMap().Return(nil, true)
 
-	svcs, err := tc.client.ListServices(context.TODO(), test.NsName)
+	svcs, err := tc.client.ListServices(context.TODO(), test.HttpNsName)
 	assert.Empty(t, svcs)
 	assert.Nil(t, err, "No error for namespace not found")
 }
@@ -137,13 +133,13 @@ func TestServiceDiscoveryClient_CreateService_HappyCase(t *testing.T) {
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(test.GetTestHttpNamespace(), true)
+	tc.mockCache.EXPECT().GetNamespaceMap().Return(getNamespaceMapForTest(), true)
 
 	tc.mockApi.EXPECT().CreateService(context.TODO(), *test.GetTestHttpNamespace(), test.SvcName).
 		Return(test.SvcId, nil)
-	tc.mockCache.EXPECT().CacheServiceId(test.NsName, test.SvcName, test.SvcId)
+	tc.mockCache.EXPECT().EvictServiceIdMap(test.HttpNsName)
 
-	err := tc.client.CreateService(context.TODO(), test.NsName, test.SvcName)
+	err := tc.client.CreateService(context.TODO(), test.HttpNsName, test.SvcName)
 	assert.Nil(t, err, "No error for happy case")
 }
 
@@ -151,13 +147,13 @@ func TestServiceDiscoveryClient_CreateService_HappyCaseForDNSNamespace(t *testin
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(test.GetTestDnsNamespace(), true)
+	tc.mockCache.EXPECT().GetNamespaceMap().Return(getNamespaceMapForTest(), true)
 
 	tc.mockApi.EXPECT().CreateService(context.TODO(), *test.GetTestDnsNamespace(), test.SvcName).
 		Return(test.SvcId, nil)
-	tc.mockCache.EXPECT().CacheServiceId(test.NsName, test.SvcName, test.SvcId)
+	tc.mockCache.EXPECT().EvictServiceIdMap(test.DnsNsName)
 
-	err := tc.client.CreateService(context.TODO(), test.NsName, test.SvcName)
+	err := tc.client.CreateService(context.TODO(), test.DnsNsName, test.SvcName)
 	assert.Nil(t, err, "No error for happy case")
 }
 
@@ -166,11 +162,10 @@ func TestServiceDiscoveryClient_CreateService_NamespaceError(t *testing.T) {
 	defer tc.close()
 
 	nsErr := errors.New("error listing namespaces")
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(nil, false)
-	tc.mockApi.EXPECT().ListNamespaces(context.TODO()).
-		Return([]*model.Namespace{}, nsErr)
+	tc.mockCache.EXPECT().GetNamespaceMap().Return(nil, false)
+	tc.mockApi.EXPECT().GetNamespaceMap(context.TODO()).Return(nil, nsErr)
 
-	err := tc.client.CreateService(context.TODO(), test.NsName, test.SvcName)
+	err := tc.client.CreateService(context.TODO(), test.HttpNsName, test.SvcName)
 	assert.Equal(t, nsErr, err)
 }
 
@@ -178,13 +173,13 @@ func TestServiceDiscoveryClient_CreateService_CreateServiceError(t *testing.T) {
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(test.GetTestDnsNamespace(), true)
+	tc.mockCache.EXPECT().GetNamespaceMap().Return(getNamespaceMapForTest(), true)
 
 	svcErr := errors.New("error creating service")
 	tc.mockApi.EXPECT().CreateService(context.TODO(), *test.GetTestDnsNamespace(), test.SvcName).
 		Return("", svcErr)
 
-	err := tc.client.CreateService(context.TODO(), test.NsName, test.SvcName)
+	err := tc.client.CreateService(context.TODO(), test.DnsNsName, test.SvcName)
 	assert.Equal(t, err, svcErr)
 }
 
@@ -192,22 +187,21 @@ func TestServiceDiscoveryClient_CreateService_CreatesNamespace_HappyCase(t *test
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(nil, false)
-	tc.mockApi.EXPECT().ListNamespaces(context.TODO()).
-		Return([]*model.Namespace{}, nil)
-	tc.mockCache.EXPECT().CacheNilNamespace(test.NsName)
+	tc.mockCache.EXPECT().GetNamespaceMap().Return(map[string]*model.Namespace{
+		test.DnsNsName: test.GetTestDnsNamespace(),
+	}, true)
 
-	tc.mockApi.EXPECT().CreateHttpNamespace(context.TODO(), test.NsName).
+	tc.mockApi.EXPECT().CreateHttpNamespace(context.TODO(), test.HttpNsName).
 		Return(test.OpId1, nil)
 	tc.mockApi.EXPECT().PollNamespaceOperation(context.TODO(), test.OpId1).
-		Return(test.NsId, nil)
-	tc.mockCache.EXPECT().CacheNamespace(test.GetTestHttpNamespace())
+		Return(test.HttpNsId, nil)
+	tc.mockCache.EXPECT().EvictNamespaceMap()
 
 	tc.mockApi.EXPECT().CreateService(context.TODO(), *test.GetTestHttpNamespace(), test.SvcName).
 		Return(test.SvcId, nil)
-	tc.mockCache.EXPECT().CacheServiceId(test.NsName, test.SvcName, test.SvcId)
+	tc.mockCache.EXPECT().EvictServiceIdMap(test.HttpNsName)
 
-	err := tc.client.CreateService(context.TODO(), test.NsName, test.SvcName)
+	err := tc.client.CreateService(context.TODO(), test.HttpNsName, test.SvcName)
 	assert.Nil(t, err, "No error for happy case")
 }
 
@@ -215,18 +209,15 @@ func TestServiceDiscoveryClient_CreateService_CreatesNamespace_PollError(t *test
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(nil, false)
-	tc.mockApi.EXPECT().ListNamespaces(context.TODO()).
-		Return([]*model.Namespace{}, nil)
-	tc.mockCache.EXPECT().CacheNilNamespace(test.NsName)
+	tc.mockCache.EXPECT().GetNamespaceMap().Return(nil, true)
 
 	pollErr := errors.New("polling error")
-	tc.mockApi.EXPECT().CreateHttpNamespace(context.TODO(), test.NsName).
+	tc.mockApi.EXPECT().CreateHttpNamespace(context.TODO(), test.HttpNsName).
 		Return(test.OpId1, nil)
 	tc.mockApi.EXPECT().PollNamespaceOperation(context.TODO(), test.OpId1).
 		Return("", pollErr)
 
-	err := tc.client.CreateService(context.TODO(), test.NsName, test.SvcName)
+	err := tc.client.CreateService(context.TODO(), test.HttpNsName, test.SvcName)
 	assert.Equal(t, pollErr, err)
 }
 
@@ -234,16 +225,13 @@ func TestServiceDiscoveryClient_CreateService_CreatesNamespace_CreateNsError(t *
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(nil, false)
-	tc.mockApi.EXPECT().ListNamespaces(context.TODO()).
-		Return([]*model.Namespace{}, nil)
-	tc.mockCache.EXPECT().CacheNilNamespace(test.NsName)
+	tc.mockCache.EXPECT().GetNamespaceMap().Return(nil, true)
 
 	nsErr := errors.New("create namespace error")
-	tc.mockApi.EXPECT().CreateHttpNamespace(context.TODO(), test.NsName).
+	tc.mockApi.EXPECT().CreateHttpNamespace(context.TODO(), test.HttpNsName).
 		Return("", nsErr)
 
-	err := tc.client.CreateService(context.TODO(), test.NsName, test.SvcName)
+	err := tc.client.CreateService(context.TODO(), test.HttpNsName, test.SvcName)
 	assert.Equal(t, nsErr, err)
 }
 
@@ -251,26 +239,26 @@ func TestServiceDiscoveryClient_GetService_HappyCase(t *testing.T) {
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetEndpoints(test.NsName, test.SvcName).Return([]*model.Endpoint{}, false)
+	tc.mockCache.EXPECT().GetEndpoints(test.HttpNsName, test.SvcName).Return(nil, false)
 
-	tc.mockCache.EXPECT().GetServiceId(test.NsName, test.SvcName)
+	tc.mockCache.EXPECT().GetServiceIdMap(test.HttpNsName).Return(nil, false)
 
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(nil, false)
-	tc.mockApi.EXPECT().ListNamespaces(context.TODO()).
-		Return([]*model.Namespace{test.GetTestHttpNamespace()}, nil)
-	tc.mockCache.EXPECT().CacheNamespace(test.GetTestHttpNamespace())
+	tc.mockCache.EXPECT().GetNamespaceMap().Return(nil, false)
+	tc.mockApi.EXPECT().GetNamespaceMap(context.TODO()).
+		Return(getNamespaceMapForTest(), nil)
+	tc.mockCache.EXPECT().CacheNamespaceMap(getNamespaceMapForTest())
 
-	tc.mockApi.EXPECT().ListServices(context.TODO(), test.NsId).
-		Return([]*model.Resource{{Id: test.SvcId, Name: test.SvcName}}, nil)
-	tc.mockCache.EXPECT().CacheServiceId(test.NsName, test.SvcName, test.SvcId)
+	tc.mockApi.EXPECT().GetServiceIdMap(context.TODO(), test.HttpNsId).
+		Return(map[string]string{test.SvcName: test.SvcId}, nil)
+	tc.mockCache.EXPECT().CacheServiceIdMap(test.HttpNsName, getServiceIdMapForTest())
 
-	tc.mockCache.EXPECT().GetEndpoints(test.NsName, test.SvcName).Return([]*model.Endpoint{}, false)
-	tc.mockApi.EXPECT().DiscoverInstances(context.TODO(), test.NsName, test.SvcName).
-		Return(testHttpInstanceSummary(), nil)
-	tc.mockCache.EXPECT().CacheEndpoints(test.NsName, test.SvcName,
+	tc.mockCache.EXPECT().GetEndpoints(test.HttpNsName, test.SvcName).Return([]*model.Endpoint{}, false)
+	tc.mockApi.EXPECT().DiscoverInstances(context.TODO(), test.HttpNsName, test.SvcName).
+		Return(getHttpInstanceSummaryForTest(), nil)
+	tc.mockCache.EXPECT().CacheEndpoints(test.HttpNsName, test.SvcName,
 		[]*model.Endpoint{test.GetTestEndpoint1(), test.GetTestEndpoint2()})
 
-	svc, err := tc.client.GetService(context.TODO(), test.NsName, test.SvcName)
+	svc, err := tc.client.GetService(context.TODO(), test.HttpNsName, test.SvcName)
 	assert.Nil(t, err)
 	assert.Equal(t, test.GetTestService(), svc)
 }
@@ -279,10 +267,10 @@ func TestServiceDiscoveryClient_GetService_CachedValues(t *testing.T) {
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetEndpoints(test.NsName, test.SvcName).
+	tc.mockCache.EXPECT().GetEndpoints(test.HttpNsName, test.SvcName).
 		Return([]*model.Endpoint{test.GetTestEndpoint1(), test.GetTestEndpoint2()}, true)
 
-	svc, err := tc.client.GetService(context.TODO(), test.NsName, test.SvcName)
+	svc, err := tc.client.GetService(context.TODO(), test.HttpNsName, test.SvcName)
 	assert.Nil(t, err)
 	assert.Equal(t, test.GetTestService(), svc)
 }
@@ -291,7 +279,7 @@ func TestServiceDiscoveryClient_RegisterEndpoints(t *testing.T) {
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetServiceId(test.NsName, test.SvcName).Return(test.SvcId, true)
+	tc.mockCache.EXPECT().GetServiceIdMap(test.HttpNsName).Return(getServiceIdMapForTest(), true)
 
 	attrs1 := map[string]string{
 		model.EndpointIpv4Attr:      test.EndptIp1,
@@ -323,9 +311,9 @@ func TestServiceDiscoveryClient_RegisterEndpoints(t *testing.T) {
 			test.OpId1: types.OperationStatusSuccess,
 			test.OpId2: types.OperationStatusSuccess}, nil)
 
-	tc.mockCache.EXPECT().EvictEndpoints(test.NsName, test.SvcName)
+	tc.mockCache.EXPECT().EvictEndpoints(test.HttpNsName, test.SvcName)
 
-	err := tc.client.RegisterEndpoints(context.TODO(), test.NsName, test.SvcName,
+	err := tc.client.RegisterEndpoints(context.TODO(), test.HttpNsName, test.SvcName,
 		[]*model.Endpoint{test.GetTestEndpoint1(), test.GetTestEndpoint2()})
 
 	assert.Nil(t, err)
@@ -335,7 +323,7 @@ func TestServiceDiscoveryClient_DeleteEndpoints(t *testing.T) {
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetServiceId(test.NsName, test.SvcName).Return(test.SvcId, true)
+	tc.mockCache.EXPECT().GetServiceIdMap(test.HttpNsName).Return(getServiceIdMapForTest(), true)
 
 	tc.mockApi.EXPECT().DeregisterInstance(context.TODO(), test.SvcId, test.EndptId1).Return(test.OpId1, nil)
 	tc.mockApi.EXPECT().DeregisterInstance(context.TODO(), test.SvcId, test.EndptId2).Return(test.OpId2, nil)
@@ -344,9 +332,9 @@ func TestServiceDiscoveryClient_DeleteEndpoints(t *testing.T) {
 			test.OpId1: types.OperationStatusSuccess,
 			test.OpId2: types.OperationStatusSuccess}, nil)
 
-	tc.mockCache.EXPECT().EvictEndpoints(test.NsName, test.SvcName)
+	tc.mockCache.EXPECT().EvictEndpoints(test.HttpNsName, test.SvcName)
 
-	err := tc.client.DeleteEndpoints(context.TODO(), test.NsName, test.SvcName,
+	err := tc.client.DeleteEndpoints(context.TODO(), test.HttpNsName, test.SvcName,
 		[]*model.Endpoint{{Id: test.EndptId1}, {Id: test.EndptId2}})
 
 	assert.Nil(t, err)
@@ -368,7 +356,7 @@ func getTestSdClient(t *testing.T) *testSdClient {
 	}
 }
 
-func testHttpInstanceSummary() []types.HttpInstanceSummary {
+func getHttpInstanceSummaryForTest() []types.HttpInstanceSummary {
 	return []types.HttpInstanceSummary{
 		{
 			InstanceId: aws.String(test.EndptId1),
@@ -397,4 +385,15 @@ func testHttpInstanceSummary() []types.HttpInstanceSummary {
 			},
 		},
 	}
+}
+
+func getNamespaceMapForTest() map[string]*model.Namespace {
+	return map[string]*model.Namespace{
+		test.HttpNsName: test.GetTestHttpNamespace(),
+		test.DnsNsName:  test.GetTestDnsNamespace(),
+	}
+}
+
+func getServiceIdMapForTest() map[string]string {
+	return map[string]string{test.SvcName: test.SvcId}
 }

--- a/pkg/controllers/cloudmap_controller.go
+++ b/pkg/controllers/cloudmap_controller.go
@@ -55,11 +55,9 @@ func (r *CloudMapReconciler) Start(ctx context.Context) error {
 func (r *CloudMapReconciler) Reconcile(ctx context.Context) error {
 	namespaces := v1.NamespaceList{}
 	if err := r.Client.List(ctx, &namespaces); err != nil {
-		r.Log.Error(err, "unable to list namespaces")
+		r.Log.Error(err, "unable to list cluster namespaces")
 		return err
 	}
-
-	//TODO: Fetch list of namespaces from Cloudmap and only reconcile the intersection
 
 	for _, ns := range namespaces.Items {
 		if err := r.reconcileNamespace(ctx, ns.Name); err != nil {

--- a/pkg/controllers/cloudmap_controller_test.go
+++ b/pkg/controllers/cloudmap_controller_test.go
@@ -37,7 +37,7 @@ func TestCloudMapReconciler_Reconcile(t *testing.T) {
 
 	mockSDClient := cloudmapMock.NewMockServiceDiscoveryClient(mockController)
 	// The service model in the Cloudmap
-	mockSDClient.EXPECT().ListServices(context.TODO(), test.NsName).
+	mockSDClient.EXPECT().ListServices(context.TODO(), test.HttpNsName).
 		Return([]*model.Service{test.GetTestServiceWithEndpoint([]*model.Endpoint{test.GetTestEndpoint1()})}, nil)
 
 	reconciler := getReconciler(t, mockSDClient, fakeClient)
@@ -49,13 +49,13 @@ func TestCloudMapReconciler_Reconcile(t *testing.T) {
 
 	// assert service import object
 	serviceImport := &v1alpha1.ServiceImport{}
-	err = fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: test.NsName, Name: test.SvcName}, serviceImport)
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: test.HttpNsName, Name: test.SvcName}, serviceImport)
 	assert.NoError(t, err)
 	assert.Equal(t, test.SvcName, serviceImport.Name, "Service imported")
 
 	// assert derived service is successfully created
 	derivedServiceList := &v1.ServiceList{}
-	err = fakeClient.List(context.TODO(), derivedServiceList, client.InNamespace(test.NsName))
+	err = fakeClient.List(context.TODO(), derivedServiceList, client.InNamespace(test.HttpNsName))
 	assert.NoError(t, err)
 	derivedService := derivedServiceList.Items[0]
 	assert.True(t, strings.Contains(derivedService.Name, "imported-"), "Derived service created", "service", derivedService.Name)
@@ -64,7 +64,7 @@ func TestCloudMapReconciler_Reconcile(t *testing.T) {
 
 	// assert endpoint slices are created
 	endpointSliceList := &v1beta1.EndpointSliceList{}
-	err = fakeClient.List(context.TODO(), endpointSliceList, client.InNamespace(test.NsName))
+	err = fakeClient.List(context.TODO(), endpointSliceList, client.InNamespace(test.HttpNsName))
 	assert.NoError(t, err)
 	endpointSlice := endpointSliceList.Items[0]
 	assert.Equal(t, test.SvcName, endpointSlice.Labels["multicluster.kubernetes.io/service-name"], "Endpoint slice is created")

--- a/pkg/controllers/controllers_common_test.go
+++ b/pkg/controllers/controllers_common_test.go
@@ -15,8 +15,8 @@ import (
 func k8sNamespaceForTest() *v1.Namespace {
 	return &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      test.NsName,
-			Namespace: test.NsName,
+			Name:      test.HttpNsName,
+			Namespace: test.HttpNsName,
 		},
 	}
 }
@@ -26,7 +26,7 @@ func k8sServiceForTest() *v1.Service {
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      test.SvcName,
-			Namespace: test.NsName,
+			Namespace: test.HttpNsName,
 		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{{
@@ -44,7 +44,7 @@ func serviceExportForTest() *v1alpha1.ServiceExport {
 	return &v1alpha1.ServiceExport{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      test.SvcName,
-			Namespace: test.NsName,
+			Namespace: test.HttpNsName,
 		},
 	}
 }
@@ -54,7 +54,7 @@ func endpointSliceForTest() *discovery.EndpointSlice {
 	protocol := v1.ProtocolTCP
 	return &discovery.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: test.NsName,
+			Namespace: test.HttpNsName,
 			Name:      test.SvcName + "-slice",
 			Labels:    map[string]string{discovery.LabelServiceName: test.SvcName},
 		},

--- a/pkg/controllers/serviceexport_controller_test.go
+++ b/pkg/controllers/serviceexport_controller_test.go
@@ -41,19 +41,19 @@ func TestServiceExportReconciler_Reconcile_NewServiceExport(t *testing.T) {
 	// expected interactions with the Cloud Map client
 	// The first get call is expected to return nil, then second call after the creation of service is
 	// supposed to return the value
-	first := mock.EXPECT().GetService(gomock.Any(), test.NsName, test.SvcName).Return(nil, nil)
-	second := mock.EXPECT().GetService(gomock.Any(), test.NsName, test.SvcName).
-		Return(&model.Service{Namespace: test.NsName, Name: test.SvcName}, nil)
+	first := mock.EXPECT().GetService(gomock.Any(), test.HttpNsName, test.SvcName).Return(nil, nil)
+	second := mock.EXPECT().GetService(gomock.Any(), test.HttpNsName, test.SvcName).
+		Return(&model.Service{Namespace: test.HttpNsName, Name: test.SvcName}, nil)
 	gomock.InOrder(first, second)
-	mock.EXPECT().CreateService(gomock.Any(), test.NsName, test.SvcName).Return(nil).Times(1)
-	mock.EXPECT().RegisterEndpoints(gomock.Any(), test.NsName, test.SvcName,
+	mock.EXPECT().CreateService(gomock.Any(), test.HttpNsName, test.SvcName).Return(nil).Times(1)
+	mock.EXPECT().RegisterEndpoints(gomock.Any(), test.HttpNsName, test.SvcName,
 		[]*model.Endpoint{test.GetTestEndpoint1()}).Return(nil).Times(1)
 
 	reconciler := getServiceExportReconciler(t, mock, fakeClient)
 
 	request := ctrl.Request{
 		NamespacedName: types.NamespacedName{
-			Namespace: test.NsName,
+			Namespace: test.HttpNsName,
 			Name:      test.SvcName,
 		},
 	}
@@ -66,7 +66,7 @@ func TestServiceExportReconciler_Reconcile_NewServiceExport(t *testing.T) {
 	assert.Equal(t, ctrl.Result{}, got, "Result should be empty")
 
 	serviceExport := &v1alpha1.ServiceExport{}
-	err = fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: test.NsName, Name: test.SvcName}, serviceExport)
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: test.HttpNsName, Name: test.SvcName}, serviceExport)
 	assert.NoError(t, err)
 	assert.Contains(t, serviceExport.Finalizers, ServiceExportFinalizer, "Finalizer added to the service export")
 }
@@ -87,15 +87,15 @@ func TestServiceExportReconciler_Reconcile_ExistingServiceExport(t *testing.T) {
 	mock := cloudmapMock.NewMockServiceDiscoveryClient(mockController)
 
 	// GetService from Cloudmap returns endpoint1 and endpoint2
-	mock.EXPECT().GetService(gomock.Any(), test.NsName, test.SvcName).
+	mock.EXPECT().GetService(gomock.Any(), test.HttpNsName, test.SvcName).
 		Return(test.GetTestService(), nil)
 	// call to delete the endpoint not present in the k8s cluster
-	mock.EXPECT().DeleteEndpoints(gomock.Any(), test.NsName, test.SvcName,
+	mock.EXPECT().DeleteEndpoints(gomock.Any(), test.HttpNsName, test.SvcName,
 		[]*model.Endpoint{test.GetTestEndpoint2()}).Return(nil).Times(1)
 
 	request := ctrl.Request{
 		NamespacedName: types.NamespacedName{
-			Namespace: test.NsName,
+			Namespace: test.HttpNsName,
 			Name:      test.SvcName,
 		},
 	}
@@ -110,7 +110,7 @@ func TestServiceExportReconciler_Reconcile_ExistingServiceExport(t *testing.T) {
 	assert.Equal(t, ctrl.Result{}, got, "Result should be empty")
 
 	serviceExport := &v1alpha1.ServiceExport{}
-	err = fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: test.NsName, Name: test.SvcName}, serviceExport)
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: test.HttpNsName, Name: test.SvcName}, serviceExport)
 	assert.NoError(t, err)
 	assert.Contains(t, serviceExport.Finalizers, ServiceExportFinalizer, "Finalizer added to the service export")
 }
@@ -134,15 +134,15 @@ func TestServiceExportReconciler_Reconcile_DeleteExistingService(t *testing.T) {
 	mock := cloudmapMock.NewMockServiceDiscoveryClient(mockController)
 
 	// GetService from Cloudmap returns endpoint1 and endpoint2
-	mock.EXPECT().GetService(gomock.Any(), test.NsName, test.SvcName).
+	mock.EXPECT().GetService(gomock.Any(), test.HttpNsName, test.SvcName).
 		Return(test.GetTestService(), nil)
 	// call to delete the endpoint in the cloudmap
-	mock.EXPECT().DeleteEndpoints(gomock.Any(), test.NsName, test.SvcName,
+	mock.EXPECT().DeleteEndpoints(gomock.Any(), test.HttpNsName, test.SvcName,
 		[]*model.Endpoint{test.GetTestEndpoint1(), test.GetTestEndpoint2()}).Return(nil).Times(1)
 
 	request := ctrl.Request{
 		NamespacedName: types.NamespacedName{
-			Namespace: test.NsName,
+			Namespace: test.HttpNsName,
 			Name:      test.SvcName,
 		},
 	}
@@ -154,7 +154,7 @@ func TestServiceExportReconciler_Reconcile_DeleteExistingService(t *testing.T) {
 	assert.Equal(t, ctrl.Result{}, got, "Result should be empty")
 
 	serviceExport := &v1alpha1.ServiceExport{}
-	err = fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: test.NsName, Name: test.SvcName}, serviceExport)
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: test.HttpNsName, Name: test.SvcName}, serviceExport)
 	assert.NoError(t, err)
 	assert.Empty(t, serviceExport.Finalizers, "Finalizer removed from the service export")
 }

--- a/pkg/controllers/utils_test.go
+++ b/pkg/controllers/utils_test.go
@@ -466,9 +466,9 @@ func TestCreateServiceImportStruct(t *testing.T) {
 			},
 			want: v1alpha1.ServiceImport{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace:   test.NsName,
+					Namespace:   test.HttpNsName,
 					Name:        test.SvcName,
-					Annotations: map[string]string{DerivedServiceAnnotation: DerivedName(test.NsName, test.SvcName)},
+					Annotations: map[string]string{DerivedServiceAnnotation: DerivedName(test.HttpNsName, test.SvcName)},
 				},
 				Spec: v1alpha1.ServiceImportSpec{
 					IPs:  []string{},
@@ -483,7 +483,7 @@ func TestCreateServiceImportStruct(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := CreateServiceImportStruct(test.NsName, test.SvcName, tt.args.servicePorts); !reflect.DeepEqual(*got, tt.want) {
+			if got := CreateServiceImportStruct(test.HttpNsName, test.SvcName, tt.args.servicePorts); !reflect.DeepEqual(*got, tt.want) {
 				t.Errorf("CreateServiceImportStruct() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -10,12 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/servicediscovery/types"
 )
 
-// Resource encapsulates a ID/name pair.
-type Resource struct {
-	Id   string
-	Name string
-}
-
 const (
 	HttpNamespaceType       NamespaceType = "HTTP"
 	DnsPrivateNamespaceType NamespaceType = "DNS_PRIVATE"

--- a/test/test-constants.go
+++ b/test/test-constants.go
@@ -7,8 +7,10 @@ import (
 )
 
 const (
-	NsName          = "ns-name"
-	NsId            = "ns-id"
+	HttpNsName      = "ns-name-1"
+	DnsNsName       = "ns-name-2"
+	HttpNsId        = "ns-id-1"
+	DnsNsId         = "ns-id-2"
 	SvcName         = "svc-name"
 	SvcId           = "svc-id"
 	EndptId1        = "tcp-192_168_0_1-1"
@@ -23,7 +25,7 @@ const (
 	ServicePortStr1 = "11"
 	Port2           = 2
 	PortStr2        = "2"
-	PortName2       = "http"
+	PortName2       = "https"
 	Protocol2       = "UDP"
 	ServicePort2    = 22
 	ServicePortStr2 = "22"
@@ -34,23 +36,23 @@ const (
 
 func GetTestHttpNamespace() *model.Namespace {
 	return &model.Namespace{
-		Id:   NsId,
-		Name: NsName,
+		Id:   HttpNsId,
+		Name: HttpNsName,
 		Type: model.HttpNamespaceType,
 	}
 }
 
 func GetTestDnsNamespace() *model.Namespace {
 	return &model.Namespace{
-		Id:   NsId,
-		Name: NsName,
+		Id:   DnsNsId,
+		Name: DnsNsName,
 		Type: model.DnsPrivateNamespaceType,
 	}
 }
 
 func GetTestService() *model.Service {
 	return &model.Service{
-		Namespace: NsName,
+		Namespace: HttpNsName,
 		Name:      SvcName,
 		Endpoints: []*model.Endpoint{GetTestEndpoint1(), GetTestEndpoint2()},
 	}
@@ -58,7 +60,7 @@ func GetTestService() *model.Service {
 
 func GetTestServiceWithEndpoint(endpoints []*model.Endpoint) *model.Service {
 	return &model.Service{
-		Namespace: NsName,
+		Namespace: HttpNsName,
 		Name:      SvcName,
 		Endpoints: endpoints,
 	}


### PR DESCRIPTION
*Issue #, if available:*
#65 

*Description of changes:*
Use maps in service and namespace cache.
This will reduce the number of calls we need to make to Cloud Map and avoid throttling. This allows us to reduce our cache TTL and import changes faster.
Some test variables were differentiated between http/dns namespace types so a lot of tests got updated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
