### PR TITLE
Differentiate dns and http ns test constants

### DIFF
--- a/integration/janitor/api_test.go
+++ b/integration/janitor/api_test.go
@@ -23,10 +23,10 @@ func TestServiceDiscoveryJanitorApi_DeleteNamespace_HappyCase(t *testing.T) {
 	mocksdk := janitorMock.NewMockSdkJanitorFacade(mockController)
 	jApi := getJanitorApi(mocksdk)
 
-	mocksdk.EXPECT().DeleteNamespace(context.TODO(), &sd.DeleteNamespaceInput{Id: aws.String(test.NsId)}).
+	mocksdk.EXPECT().DeleteNamespace(context.TODO(), &sd.DeleteNamespaceInput{Id: aws.String(test.HttpNsId)}).
 		Return(&sd.DeleteNamespaceOutput{OperationId: aws.String(test.OpId1)}, nil)
 
-	opId, err := jApi.DeleteNamespace(context.TODO(), test.NsId)
+	opId, err := jApi.DeleteNamespace(context.TODO(), test.HttpNsId)
 	assert.Nil(t, err, "No error for happy case")
 	assert.Equal(t, test.OpId1, opId)
 }

--- a/integration/janitor/janitor_test.go
+++ b/integration/janitor/janitor_test.go
@@ -29,10 +29,10 @@ func TestCleanupHappyCase(t *testing.T) {
 	defer tj.close()
 
 	tj.mockApi.EXPECT().ListNamespaces(context.TODO()).
-		Return([]*model.Namespace{{Id: test.NsId, Name: test.NsName}}, nil)
-	tj.mockApi.EXPECT().ListServices(context.TODO(), test.NsId).
+		Return([]*model.Namespace{{Id: test.HttpNsId, Name: test.HttpNsName}}, nil)
+	tj.mockApi.EXPECT().ListServices(context.TODO(), test.HttpNsId).
 		Return([]*model.Resource{{Id: test.SvcId, Name: test.SvcName}}, nil)
-	tj.mockApi.EXPECT().DiscoverInstances(context.TODO(), test.NsName, test.SvcName).
+	tj.mockApi.EXPECT().DiscoverInstances(context.TODO(), test.HttpNsName, test.SvcName).
 		Return([]types.HttpInstanceSummary{{InstanceId: aws.String(test.EndptId1)}}, nil)
 
 	tj.mockApi.EXPECT().DeregisterInstance(context.TODO(), test.SvcId, test.EndptId1).
@@ -41,12 +41,12 @@ func TestCleanupHappyCase(t *testing.T) {
 		Return(map[string]types.OperationStatus{test.OpId1: types.OperationStatusSuccess}, nil)
 	tj.mockApi.EXPECT().DeleteService(context.TODO(), test.SvcId).
 		Return(nil)
-	tj.mockApi.EXPECT().DeleteNamespace(context.TODO(), test.NsId).
+	tj.mockApi.EXPECT().DeleteNamespace(context.TODO(), test.HttpNsId).
 		Return(test.OpId2, nil)
 	tj.mockApi.EXPECT().PollNamespaceOperation(context.TODO(), test.OpId2).
-		Return(test.NsId, nil)
+		Return(test.HttpNsId, nil)
 
-	tj.janitor.Cleanup(context.TODO(), test.NsName)
+	tj.janitor.Cleanup(context.TODO(), test.HttpNsName)
 	assert.False(t, *tj.failed)
 }
 
@@ -57,7 +57,7 @@ func TestCleanupNothingToClean(t *testing.T) {
 	tj.mockApi.EXPECT().ListNamespaces(context.TODO()).
 		Return([]*model.Namespace{}, nil)
 
-	tj.janitor.Cleanup(context.TODO(), test.NsName)
+	tj.janitor.Cleanup(context.TODO(), test.HttpNsName)
 	assert.False(t, *tj.failed)
 }
 

--- a/pkg/cloudmap/cache_test.go
+++ b/pkg/cloudmap/cache_test.go
@@ -39,7 +39,7 @@ func TestServiceDiscoveryClientCacheGetNamespace_Found(t *testing.T) {
 	sdc := NewDefaultServiceDiscoveryClientCache()
 	sdc.CacheNamespace(test.GetTestHttpNamespace())
 
-	ns, found := sdc.GetNamespace(test.NsName)
+	ns, found := sdc.GetNamespace(test.HttpNsName)
 	assert.True(t, found)
 	assert.Equal(t, test.GetTestHttpNamespace(), ns)
 }
@@ -47,16 +47,16 @@ func TestServiceDiscoveryClientCacheGetNamespace_Found(t *testing.T) {
 func TestServiceDiscoveryClientCacheGetNamespace_NotFound(t *testing.T) {
 	sdc := NewDefaultServiceDiscoveryClientCache()
 
-	ns, found := sdc.GetNamespace(test.NsName)
+	ns, found := sdc.GetNamespace(test.HttpNsName)
 	assert.False(t, found)
 	assert.Nil(t, ns)
 }
 
 func TestServiceDiscoveryClientCacheGetNamespace_Nil(t *testing.T) {
 	sdc := NewDefaultServiceDiscoveryClientCache()
-	sdc.CacheNilNamespace(test.NsName)
+	sdc.CacheNilNamespace(test.HttpNsName)
 
-	ns, found := sdc.GetNamespace(test.NsName)
+	ns, found := sdc.GetNamespace(test.HttpNsName)
 	assert.True(t, found)
 	assert.Nil(t, ns)
 }
@@ -66,18 +66,18 @@ func TestServiceDiscoveryClientCacheGetNamespace_Corrupt(t *testing.T) {
 	if !ok {
 		t.Fatalf("failed to create cache")
 	}
-	sdc.cache.Add(sdc.buildNsKey(test.NsName), &model.Resource{}, time.Minute)
+	sdc.cache.Add(sdc.buildNsKey(test.HttpNsName), &model.Resource{}, time.Minute)
 
-	ns, found := sdc.GetNamespace(test.NsName)
+	ns, found := sdc.GetNamespace(test.HttpNsName)
 	assert.False(t, found)
 	assert.Nil(t, ns)
 }
 
 func TestServiceDiscoveryClientCacheGetServiceId_Found(t *testing.T) {
 	sdc := NewDefaultServiceDiscoveryClientCache()
-	sdc.CacheServiceId(test.NsName, test.SvcName, test.SvcId)
+	sdc.CacheServiceId(test.HttpNsName, test.SvcName, test.SvcId)
 
-	svcId, found := sdc.GetServiceId(test.NsName, test.SvcName)
+	svcId, found := sdc.GetServiceId(test.HttpNsName, test.SvcName)
 	assert.True(t, found)
 	assert.Equal(t, test.SvcId, svcId)
 }
@@ -85,7 +85,7 @@ func TestServiceDiscoveryClientCacheGetServiceId_Found(t *testing.T) {
 func TestServiceDiscoveryClientCacheGetServiceId_NotFound(t *testing.T) {
 	sdc := NewDefaultServiceDiscoveryClientCache()
 
-	svcId, found := sdc.GetServiceId(test.NsName, test.SvcName)
+	svcId, found := sdc.GetServiceId(test.HttpNsName, test.SvcName)
 	assert.False(t, found)
 	assert.Empty(t, svcId)
 }
@@ -95,17 +95,17 @@ func TestServiceDiscoveryClientCacheGetServiceId_Corrupt(t *testing.T) {
 	if !ok {
 		t.Fatalf("failed to create cache")
 	}
-	sdc.cache.Add(sdc.buildSvcKey(test.NsName, test.SvcName), &model.Resource{}, time.Minute)
-	svcId, found := sdc.GetServiceId(test.NsName, test.SvcName)
+	sdc.cache.Add(sdc.buildSvcKey(test.HttpNsName, test.SvcName), &model.Resource{}, time.Minute)
+	svcId, found := sdc.GetServiceId(test.HttpNsName, test.SvcName)
 	assert.False(t, found)
 	assert.Empty(t, svcId)
 }
 
 func TestServiceDiscoveryClientCacheGetEndpoints_Found(t *testing.T) {
 	sdc := NewDefaultServiceDiscoveryClientCache()
-	sdc.CacheEndpoints(test.NsName, test.SvcName, []*model.Endpoint{test.GetTestEndpoint1(), test.GetTestEndpoint2()})
+	sdc.CacheEndpoints(test.HttpNsName, test.SvcName, []*model.Endpoint{test.GetTestEndpoint1(), test.GetTestEndpoint2()})
 
-	endpts, found := sdc.GetEndpoints(test.NsName, test.SvcName)
+	endpts, found := sdc.GetEndpoints(test.HttpNsName, test.SvcName)
 	assert.True(t, found)
 	assert.Equal(t, []*model.Endpoint{test.GetTestEndpoint1(), test.GetTestEndpoint2()}, endpts)
 }
@@ -113,7 +113,7 @@ func TestServiceDiscoveryClientCacheGetEndpoints_Found(t *testing.T) {
 func TestServiceDiscoveryClientCacheGetEndpoints_NotFound(t *testing.T) {
 	sdc := NewDefaultServiceDiscoveryClientCache()
 
-	endpts, found := sdc.GetEndpoints(test.NsName, test.SvcName)
+	endpts, found := sdc.GetEndpoints(test.HttpNsName, test.SvcName)
 	assert.False(t, found)
 	assert.Nil(t, endpts)
 }
@@ -124,18 +124,18 @@ func TestServiceDiscoveryClientCacheGetEndpoints_Corrupt(t *testing.T) {
 		t.Fatalf("failed to create cache")
 	}
 
-	sdc.cache.Add(sdc.buildEndptsKey(test.NsName, test.SvcName), &model.Resource{}, time.Minute)
-	endpts, found := sdc.GetEndpoints(test.NsName, test.SvcName)
+	sdc.cache.Add(sdc.buildEndptsKey(test.HttpNsName, test.SvcName), &model.Resource{}, time.Minute)
+	endpts, found := sdc.GetEndpoints(test.HttpNsName, test.SvcName)
 	assert.False(t, found)
 	assert.Nil(t, endpts)
 }
 
 func TestServiceDiscoveryClientEvictEndpoints(t *testing.T) {
 	sdc := NewDefaultServiceDiscoveryClientCache()
-	sdc.CacheEndpoints(test.NsName, test.SvcName, []*model.Endpoint{test.GetTestEndpoint1(), test.GetTestEndpoint2()})
-	sdc.EvictEndpoints(test.NsName, test.SvcName)
+	sdc.CacheEndpoints(test.HttpNsName, test.SvcName, []*model.Endpoint{test.GetTestEndpoint1(), test.GetTestEndpoint2()})
+	sdc.EvictEndpoints(test.HttpNsName, test.SvcName)
 
-	endpts, found := sdc.GetEndpoints(test.NsName, test.SvcName)
+	endpts, found := sdc.GetEndpoints(test.HttpNsName, test.SvcName)
 	assert.False(t, found)
 	assert.Nil(t, endpts)
 }

--- a/pkg/cloudmap/client_test.go
+++ b/pkg/cloudmap/client_test.go
@@ -32,22 +32,22 @@ func TestServiceDiscoveryClient_ListServices_HappyCase(t *testing.T) {
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(nil, false)
+	tc.mockCache.EXPECT().GetNamespace(test.HttpNsName).Return(nil, false)
 	tc.mockApi.EXPECT().ListNamespaces(context.TODO()).
 		Return([]*model.Namespace{test.GetTestHttpNamespace()}, nil)
 	tc.mockCache.EXPECT().CacheNamespace(test.GetTestHttpNamespace())
 
-	tc.mockApi.EXPECT().ListServices(context.TODO(), test.NsId).
+	tc.mockApi.EXPECT().ListServices(context.TODO(), test.HttpNsId).
 		Return([]*model.Resource{{Name: test.SvcName, Id: test.SvcId}}, nil)
-	tc.mockCache.EXPECT().CacheServiceId(test.NsName, test.SvcName, test.SvcId)
+	tc.mockCache.EXPECT().CacheServiceId(test.HttpNsName, test.SvcName, test.SvcId)
 
-	tc.mockCache.EXPECT().GetEndpoints(test.NsName, test.SvcName).Return(nil, false)
-	tc.mockApi.EXPECT().DiscoverInstances(context.TODO(), test.NsName, test.SvcName).
+	tc.mockCache.EXPECT().GetEndpoints(test.HttpNsName, test.SvcName).Return(nil, false)
+	tc.mockApi.EXPECT().DiscoverInstances(context.TODO(), test.HttpNsName, test.SvcName).
 		Return(testHttpInstanceSummary(), nil)
-	tc.mockCache.EXPECT().CacheEndpoints(test.NsName, test.SvcName,
+	tc.mockCache.EXPECT().CacheEndpoints(test.HttpNsName, test.SvcName,
 		[]*model.Endpoint{test.GetTestEndpoint1(), test.GetTestEndpoint2()})
 
-	svcs, err := tc.client.ListServices(context.TODO(), test.NsName)
+	svcs, err := tc.client.ListServices(context.TODO(), test.HttpNsName)
 	assert.Equal(t, []*model.Service{test.GetTestService()}, svcs)
 	assert.Nil(t, err, "No error for happy case")
 }
@@ -56,16 +56,16 @@ func TestServiceDiscoveryClient_ListServices_HappyCaseCachedResults(t *testing.T
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(test.GetTestHttpNamespace(), true)
+	tc.mockCache.EXPECT().GetNamespace(test.HttpNsName).Return(test.GetTestHttpNamespace(), true)
 
-	tc.mockApi.EXPECT().ListServices(context.TODO(), test.NsId).
+	tc.mockApi.EXPECT().ListServices(context.TODO(), test.HttpNsId).
 		Return([]*model.Resource{{Name: test.SvcName, Id: test.SvcId}}, nil)
-	tc.mockCache.EXPECT().CacheServiceId(test.NsName, test.SvcName, test.SvcId)
+	tc.mockCache.EXPECT().CacheServiceId(test.HttpNsName, test.SvcName, test.SvcId)
 
-	tc.mockCache.EXPECT().GetEndpoints(test.NsName, test.SvcName).
+	tc.mockCache.EXPECT().GetEndpoints(test.HttpNsName, test.SvcName).
 		Return([]*model.Endpoint{test.GetTestEndpoint1(), test.GetTestEndpoint2()}, true)
 
-	svcs, err := tc.client.ListServices(context.TODO(), test.NsName)
+	svcs, err := tc.client.ListServices(context.TODO(), test.HttpNsName)
 	assert.Equal(t, []*model.Service{test.GetTestService()}, svcs)
 	assert.Nil(t, err, "No error for happy case")
 }
@@ -75,11 +75,11 @@ func TestServiceDiscoveryClient_ListServices_NamespaceError(t *testing.T) {
 	defer tc.close()
 
 	nsErr := errors.New("error listing namespaces")
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(nil, false)
+	tc.mockCache.EXPECT().GetNamespace(test.HttpNsName).Return(nil, false)
 	tc.mockApi.EXPECT().ListNamespaces(context.TODO()).
 		Return(nil, nsErr)
 
-	svcs, err := tc.client.ListServices(context.TODO(), test.NsName)
+	svcs, err := tc.client.ListServices(context.TODO(), test.HttpNsName)
 	assert.Equal(t, nsErr, err)
 	assert.Empty(t, svcs)
 }
@@ -88,13 +88,13 @@ func TestServiceDiscoveryClient_ListServices_ServiceError(t *testing.T) {
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(test.GetTestHttpNamespace(), true)
+	tc.mockCache.EXPECT().GetNamespace(test.HttpNsName).Return(test.GetTestHttpNamespace(), true)
 
 	svcErr := errors.New("error listing services")
-	tc.mockApi.EXPECT().ListServices(context.TODO(), test.NsId).
+	tc.mockApi.EXPECT().ListServices(context.TODO(), test.HttpNsId).
 		Return([]*model.Resource{}, svcErr)
 
-	svcs, err := tc.client.ListServices(context.TODO(), test.NsName)
+	svcs, err := tc.client.ListServices(context.TODO(), test.HttpNsName)
 	assert.Equal(t, svcErr, err)
 	assert.Empty(t, svcs)
 }
@@ -103,18 +103,18 @@ func TestServiceDiscoveryClient_ListServices_InstanceError(t *testing.T) {
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(test.GetTestHttpNamespace(), true)
+	tc.mockCache.EXPECT().GetNamespace(test.HttpNsName).Return(test.GetTestHttpNamespace(), true)
 
-	tc.mockApi.EXPECT().ListServices(context.TODO(), test.NsId).
+	tc.mockApi.EXPECT().ListServices(context.TODO(), test.HttpNsId).
 		Return([]*model.Resource{{Name: test.SvcName, Id: test.SvcId}}, nil)
-	tc.mockCache.EXPECT().CacheServiceId(test.NsName, test.SvcName, test.SvcId)
+	tc.mockCache.EXPECT().CacheServiceId(test.HttpNsName, test.SvcName, test.SvcId)
 
 	endptErr := errors.New("error listing endpoints")
-	tc.mockCache.EXPECT().GetEndpoints(test.NsName, test.SvcName).Return(nil, false)
-	tc.mockApi.EXPECT().DiscoverInstances(context.TODO(), test.NsName, test.SvcName).
+	tc.mockCache.EXPECT().GetEndpoints(test.HttpNsName, test.SvcName).Return(nil, false)
+	tc.mockApi.EXPECT().DiscoverInstances(context.TODO(), test.HttpNsName, test.SvcName).
 		Return([]types.HttpInstanceSummary{}, endptErr)
 
-	svcs, err := tc.client.ListServices(context.TODO(), test.NsName)
+	svcs, err := tc.client.ListServices(context.TODO(), test.HttpNsName)
 	assert.Equal(t, endptErr, err)
 	assert.Empty(t, svcs)
 }
@@ -123,12 +123,12 @@ func TestServiceDiscoveryClient_ListServices_NamespaceNotFound(t *testing.T) {
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(nil, false)
+	tc.mockCache.EXPECT().GetNamespace(test.HttpNsName).Return(nil, false)
 	tc.mockApi.EXPECT().ListNamespaces(context.TODO()).
 		Return([]*model.Namespace{}, nil)
-	tc.mockCache.EXPECT().CacheNilNamespace(test.NsName)
+	tc.mockCache.EXPECT().CacheNilNamespace(test.HttpNsName)
 
-	svcs, err := tc.client.ListServices(context.TODO(), test.NsName)
+	svcs, err := tc.client.ListServices(context.TODO(), test.HttpNsName)
 	assert.Empty(t, svcs)
 	assert.Nil(t, err, "No error for namespace not found")
 }
@@ -137,13 +137,13 @@ func TestServiceDiscoveryClient_CreateService_HappyCase(t *testing.T) {
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(test.GetTestHttpNamespace(), true)
+	tc.mockCache.EXPECT().GetNamespace(test.HttpNsName).Return(test.GetTestHttpNamespace(), true)
 
 	tc.mockApi.EXPECT().CreateService(context.TODO(), *test.GetTestHttpNamespace(), test.SvcName).
 		Return(test.SvcId, nil)
-	tc.mockCache.EXPECT().CacheServiceId(test.NsName, test.SvcName, test.SvcId)
+	tc.mockCache.EXPECT().CacheServiceId(test.HttpNsName, test.SvcName, test.SvcId)
 
-	err := tc.client.CreateService(context.TODO(), test.NsName, test.SvcName)
+	err := tc.client.CreateService(context.TODO(), test.HttpNsName, test.SvcName)
 	assert.Nil(t, err, "No error for happy case")
 }
 
@@ -151,13 +151,13 @@ func TestServiceDiscoveryClient_CreateService_HappyCaseForDNSNamespace(t *testin
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(test.GetTestDnsNamespace(), true)
+	tc.mockCache.EXPECT().GetNamespace(test.HttpNsName).Return(test.GetTestDnsNamespace(), true)
 
 	tc.mockApi.EXPECT().CreateService(context.TODO(), *test.GetTestDnsNamespace(), test.SvcName).
 		Return(test.SvcId, nil)
-	tc.mockCache.EXPECT().CacheServiceId(test.NsName, test.SvcName, test.SvcId)
+	tc.mockCache.EXPECT().CacheServiceId(test.HttpNsName, test.SvcName, test.SvcId)
 
-	err := tc.client.CreateService(context.TODO(), test.NsName, test.SvcName)
+	err := tc.client.CreateService(context.TODO(), test.HttpNsName, test.SvcName)
 	assert.Nil(t, err, "No error for happy case")
 }
 
@@ -166,11 +166,11 @@ func TestServiceDiscoveryClient_CreateService_NamespaceError(t *testing.T) {
 	defer tc.close()
 
 	nsErr := errors.New("error listing namespaces")
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(nil, false)
+	tc.mockCache.EXPECT().GetNamespace(test.HttpNsName).Return(nil, false)
 	tc.mockApi.EXPECT().ListNamespaces(context.TODO()).
 		Return([]*model.Namespace{}, nsErr)
 
-	err := tc.client.CreateService(context.TODO(), test.NsName, test.SvcName)
+	err := tc.client.CreateService(context.TODO(), test.HttpNsName, test.SvcName)
 	assert.Equal(t, nsErr, err)
 }
 
@@ -178,13 +178,13 @@ func TestServiceDiscoveryClient_CreateService_CreateServiceError(t *testing.T) {
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(test.GetTestDnsNamespace(), true)
+	tc.mockCache.EXPECT().GetNamespace(test.HttpNsName).Return(test.GetTestDnsNamespace(), true)
 
 	svcErr := errors.New("error creating service")
 	tc.mockApi.EXPECT().CreateService(context.TODO(), *test.GetTestDnsNamespace(), test.SvcName).
 		Return("", svcErr)
 
-	err := tc.client.CreateService(context.TODO(), test.NsName, test.SvcName)
+	err := tc.client.CreateService(context.TODO(), test.HttpNsName, test.SvcName)
 	assert.Equal(t, err, svcErr)
 }
 
@@ -192,22 +192,22 @@ func TestServiceDiscoveryClient_CreateService_CreatesNamespace_HappyCase(t *test
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(nil, false)
+	tc.mockCache.EXPECT().GetNamespace(test.HttpNsName).Return(nil, false)
 	tc.mockApi.EXPECT().ListNamespaces(context.TODO()).
 		Return([]*model.Namespace{}, nil)
-	tc.mockCache.EXPECT().CacheNilNamespace(test.NsName)
+	tc.mockCache.EXPECT().CacheNilNamespace(test.HttpNsName)
 
-	tc.mockApi.EXPECT().CreateHttpNamespace(context.TODO(), test.NsName).
+	tc.mockApi.EXPECT().CreateHttpNamespace(context.TODO(), test.HttpNsName).
 		Return(test.OpId1, nil)
 	tc.mockApi.EXPECT().PollNamespaceOperation(context.TODO(), test.OpId1).
-		Return(test.NsId, nil)
+		Return(test.HttpNsId, nil)
 	tc.mockCache.EXPECT().CacheNamespace(test.GetTestHttpNamespace())
 
 	tc.mockApi.EXPECT().CreateService(context.TODO(), *test.GetTestHttpNamespace(), test.SvcName).
 		Return(test.SvcId, nil)
-	tc.mockCache.EXPECT().CacheServiceId(test.NsName, test.SvcName, test.SvcId)
+	tc.mockCache.EXPECT().CacheServiceId(test.HttpNsName, test.SvcName, test.SvcId)
 
-	err := tc.client.CreateService(context.TODO(), test.NsName, test.SvcName)
+	err := tc.client.CreateService(context.TODO(), test.HttpNsName, test.SvcName)
 	assert.Nil(t, err, "No error for happy case")
 }
 
@@ -215,18 +215,18 @@ func TestServiceDiscoveryClient_CreateService_CreatesNamespace_PollError(t *test
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(nil, false)
+	tc.mockCache.EXPECT().GetNamespace(test.HttpNsName).Return(nil, false)
 	tc.mockApi.EXPECT().ListNamespaces(context.TODO()).
 		Return([]*model.Namespace{}, nil)
-	tc.mockCache.EXPECT().CacheNilNamespace(test.NsName)
+	tc.mockCache.EXPECT().CacheNilNamespace(test.HttpNsName)
 
 	pollErr := errors.New("polling error")
-	tc.mockApi.EXPECT().CreateHttpNamespace(context.TODO(), test.NsName).
+	tc.mockApi.EXPECT().CreateHttpNamespace(context.TODO(), test.HttpNsName).
 		Return(test.OpId1, nil)
 	tc.mockApi.EXPECT().PollNamespaceOperation(context.TODO(), test.OpId1).
 		Return("", pollErr)
 
-	err := tc.client.CreateService(context.TODO(), test.NsName, test.SvcName)
+	err := tc.client.CreateService(context.TODO(), test.HttpNsName, test.SvcName)
 	assert.Equal(t, pollErr, err)
 }
 
@@ -234,16 +234,16 @@ func TestServiceDiscoveryClient_CreateService_CreatesNamespace_CreateNsError(t *
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(nil, false)
+	tc.mockCache.EXPECT().GetNamespace(test.HttpNsName).Return(nil, false)
 	tc.mockApi.EXPECT().ListNamespaces(context.TODO()).
 		Return([]*model.Namespace{}, nil)
-	tc.mockCache.EXPECT().CacheNilNamespace(test.NsName)
+	tc.mockCache.EXPECT().CacheNilNamespace(test.HttpNsName)
 
 	nsErr := errors.New("create namespace error")
-	tc.mockApi.EXPECT().CreateHttpNamespace(context.TODO(), test.NsName).
+	tc.mockApi.EXPECT().CreateHttpNamespace(context.TODO(), test.HttpNsName).
 		Return("", nsErr)
 
-	err := tc.client.CreateService(context.TODO(), test.NsName, test.SvcName)
+	err := tc.client.CreateService(context.TODO(), test.HttpNsName, test.SvcName)
 	assert.Equal(t, nsErr, err)
 }
 
@@ -251,26 +251,26 @@ func TestServiceDiscoveryClient_GetService_HappyCase(t *testing.T) {
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetEndpoints(test.NsName, test.SvcName).Return([]*model.Endpoint{}, false)
+	tc.mockCache.EXPECT().GetEndpoints(test.HttpNsName, test.SvcName).Return([]*model.Endpoint{}, false)
 
-	tc.mockCache.EXPECT().GetServiceId(test.NsName, test.SvcName)
+	tc.mockCache.EXPECT().GetServiceId(test.HttpNsName, test.SvcName)
 
-	tc.mockCache.EXPECT().GetNamespace(test.NsName).Return(nil, false)
+	tc.mockCache.EXPECT().GetNamespace(test.HttpNsName).Return(nil, false)
 	tc.mockApi.EXPECT().ListNamespaces(context.TODO()).
 		Return([]*model.Namespace{test.GetTestHttpNamespace()}, nil)
 	tc.mockCache.EXPECT().CacheNamespace(test.GetTestHttpNamespace())
 
-	tc.mockApi.EXPECT().ListServices(context.TODO(), test.NsId).
+	tc.mockApi.EXPECT().ListServices(context.TODO(), test.HttpNsId).
 		Return([]*model.Resource{{Id: test.SvcId, Name: test.SvcName}}, nil)
-	tc.mockCache.EXPECT().CacheServiceId(test.NsName, test.SvcName, test.SvcId)
+	tc.mockCache.EXPECT().CacheServiceId(test.HttpNsName, test.SvcName, test.SvcId)
 
-	tc.mockCache.EXPECT().GetEndpoints(test.NsName, test.SvcName).Return([]*model.Endpoint{}, false)
-	tc.mockApi.EXPECT().DiscoverInstances(context.TODO(), test.NsName, test.SvcName).
+	tc.mockCache.EXPECT().GetEndpoints(test.HttpNsName, test.SvcName).Return([]*model.Endpoint{}, false)
+	tc.mockApi.EXPECT().DiscoverInstances(context.TODO(), test.HttpNsName, test.SvcName).
 		Return(testHttpInstanceSummary(), nil)
-	tc.mockCache.EXPECT().CacheEndpoints(test.NsName, test.SvcName,
+	tc.mockCache.EXPECT().CacheEndpoints(test.HttpNsName, test.SvcName,
 		[]*model.Endpoint{test.GetTestEndpoint1(), test.GetTestEndpoint2()})
 
-	svc, err := tc.client.GetService(context.TODO(), test.NsName, test.SvcName)
+	svc, err := tc.client.GetService(context.TODO(), test.HttpNsName, test.SvcName)
 	assert.Nil(t, err)
 	assert.Equal(t, test.GetTestService(), svc)
 }
@@ -279,10 +279,10 @@ func TestServiceDiscoveryClient_GetService_CachedValues(t *testing.T) {
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetEndpoints(test.NsName, test.SvcName).
+	tc.mockCache.EXPECT().GetEndpoints(test.HttpNsName, test.SvcName).
 		Return([]*model.Endpoint{test.GetTestEndpoint1(), test.GetTestEndpoint2()}, true)
 
-	svc, err := tc.client.GetService(context.TODO(), test.NsName, test.SvcName)
+	svc, err := tc.client.GetService(context.TODO(), test.HttpNsName, test.SvcName)
 	assert.Nil(t, err)
 	assert.Equal(t, test.GetTestService(), svc)
 }
@@ -291,7 +291,7 @@ func TestServiceDiscoveryClient_RegisterEndpoints(t *testing.T) {
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetServiceId(test.NsName, test.SvcName).Return(test.SvcId, true)
+	tc.mockCache.EXPECT().GetServiceId(test.HttpNsName, test.SvcName).Return(test.SvcId, true)
 
 	attrs1 := map[string]string{
 		model.EndpointIpv4Attr:      test.EndptIp1,
@@ -323,9 +323,9 @@ func TestServiceDiscoveryClient_RegisterEndpoints(t *testing.T) {
 			test.OpId1: types.OperationStatusSuccess,
 			test.OpId2: types.OperationStatusSuccess}, nil)
 
-	tc.mockCache.EXPECT().EvictEndpoints(test.NsName, test.SvcName)
+	tc.mockCache.EXPECT().EvictEndpoints(test.HttpNsName, test.SvcName)
 
-	err := tc.client.RegisterEndpoints(context.TODO(), test.NsName, test.SvcName,
+	err := tc.client.RegisterEndpoints(context.TODO(), test.HttpNsName, test.SvcName,
 		[]*model.Endpoint{test.GetTestEndpoint1(), test.GetTestEndpoint2()})
 
 	assert.Nil(t, err)
@@ -335,7 +335,7 @@ func TestServiceDiscoveryClient_DeleteEndpoints(t *testing.T) {
 	tc := getTestSdClient(t)
 	defer tc.close()
 
-	tc.mockCache.EXPECT().GetServiceId(test.NsName, test.SvcName).Return(test.SvcId, true)
+	tc.mockCache.EXPECT().GetServiceId(test.HttpNsName, test.SvcName).Return(test.SvcId, true)
 
 	tc.mockApi.EXPECT().DeregisterInstance(context.TODO(), test.SvcId, test.EndptId1).Return(test.OpId1, nil)
 	tc.mockApi.EXPECT().DeregisterInstance(context.TODO(), test.SvcId, test.EndptId2).Return(test.OpId2, nil)
@@ -344,9 +344,9 @@ func TestServiceDiscoveryClient_DeleteEndpoints(t *testing.T) {
 			test.OpId1: types.OperationStatusSuccess,
 			test.OpId2: types.OperationStatusSuccess}, nil)
 
-	tc.mockCache.EXPECT().EvictEndpoints(test.NsName, test.SvcName)
+	tc.mockCache.EXPECT().EvictEndpoints(test.HttpNsName, test.SvcName)
 
-	err := tc.client.DeleteEndpoints(context.TODO(), test.NsName, test.SvcName,
+	err := tc.client.DeleteEndpoints(context.TODO(), test.HttpNsName, test.SvcName,
 		[]*model.Endpoint{{Id: test.EndptId1}, {Id: test.EndptId2}})
 
 	assert.Nil(t, err)

--- a/pkg/controllers/cloudmap_controller_test.go
+++ b/pkg/controllers/cloudmap_controller_test.go
@@ -37,7 +37,7 @@ func TestCloudMapReconciler_Reconcile(t *testing.T) {
 
 	mockSDClient := cloudmapMock.NewMockServiceDiscoveryClient(mockController)
 	// The service model in the Cloudmap
-	mockSDClient.EXPECT().ListServices(context.TODO(), test.NsName).
+	mockSDClient.EXPECT().ListServices(context.TODO(), test.HttpNsName).
 		Return([]*model.Service{test.GetTestServiceWithEndpoint([]*model.Endpoint{test.GetTestEndpoint1()})}, nil)
 
 	reconciler := getReconciler(t, mockSDClient, fakeClient)
@@ -49,13 +49,13 @@ func TestCloudMapReconciler_Reconcile(t *testing.T) {
 
 	// assert service import object
 	serviceImport := &v1alpha1.ServiceImport{}
-	err = fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: test.NsName, Name: test.SvcName}, serviceImport)
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: test.HttpNsName, Name: test.SvcName}, serviceImport)
 	assert.NoError(t, err)
 	assert.Equal(t, test.SvcName, serviceImport.Name, "Service imported")
 
 	// assert derived service is successfully created
 	derivedServiceList := &v1.ServiceList{}
-	err = fakeClient.List(context.TODO(), derivedServiceList, client.InNamespace(test.NsName))
+	err = fakeClient.List(context.TODO(), derivedServiceList, client.InNamespace(test.HttpNsName))
 	assert.NoError(t, err)
 	derivedService := derivedServiceList.Items[0]
 	assert.True(t, strings.Contains(derivedService.Name, "imported-"), "Derived service created", "service", derivedService.Name)
@@ -64,7 +64,7 @@ func TestCloudMapReconciler_Reconcile(t *testing.T) {
 
 	// assert endpoint slices are created
 	endpointSliceList := &v1beta1.EndpointSliceList{}
-	err = fakeClient.List(context.TODO(), endpointSliceList, client.InNamespace(test.NsName))
+	err = fakeClient.List(context.TODO(), endpointSliceList, client.InNamespace(test.HttpNsName))
 	assert.NoError(t, err)
 	endpointSlice := endpointSliceList.Items[0]
 	assert.Equal(t, test.SvcName, endpointSlice.Labels["multicluster.kubernetes.io/service-name"], "Endpoint slice is created")

--- a/pkg/controllers/controllers_common_test.go
+++ b/pkg/controllers/controllers_common_test.go
@@ -15,8 +15,8 @@ import (
 func k8sNamespaceForTest() *v1.Namespace {
 	return &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      test.NsName,
-			Namespace: test.NsName,
+			Name:      test.HttpNsName,
+			Namespace: test.HttpNsName,
 		},
 	}
 }
@@ -26,7 +26,7 @@ func k8sServiceForTest() *v1.Service {
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      test.SvcName,
-			Namespace: test.NsName,
+			Namespace: test.HttpNsName,
 		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{{
@@ -44,7 +44,7 @@ func serviceExportForTest() *v1alpha1.ServiceExport {
 	return &v1alpha1.ServiceExport{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      test.SvcName,
-			Namespace: test.NsName,
+			Namespace: test.HttpNsName,
 		},
 	}
 }
@@ -54,7 +54,7 @@ func endpointSliceForTest() *discovery.EndpointSlice {
 	protocol := v1.ProtocolTCP
 	return &discovery.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: test.NsName,
+			Namespace: test.HttpNsName,
 			Name:      test.SvcName + "-slice",
 			Labels:    map[string]string{discovery.LabelServiceName: test.SvcName},
 		},

--- a/pkg/controllers/serviceexport_controller_test.go
+++ b/pkg/controllers/serviceexport_controller_test.go
@@ -41,19 +41,19 @@ func TestServiceExportReconciler_Reconcile_NewServiceExport(t *testing.T) {
 	// expected interactions with the Cloud Map client
 	// The first get call is expected to return nil, then second call after the creation of service is
 	// supposed to return the value
-	first := mock.EXPECT().GetService(gomock.Any(), test.NsName, test.SvcName).Return(nil, nil)
-	second := mock.EXPECT().GetService(gomock.Any(), test.NsName, test.SvcName).
-		Return(&model.Service{Namespace: test.NsName, Name: test.SvcName}, nil)
+	first := mock.EXPECT().GetService(gomock.Any(), test.HttpNsName, test.SvcName).Return(nil, nil)
+	second := mock.EXPECT().GetService(gomock.Any(), test.HttpNsName, test.SvcName).
+		Return(&model.Service{Namespace: test.HttpNsName, Name: test.SvcName}, nil)
 	gomock.InOrder(first, second)
-	mock.EXPECT().CreateService(gomock.Any(), test.NsName, test.SvcName).Return(nil).Times(1)
-	mock.EXPECT().RegisterEndpoints(gomock.Any(), test.NsName, test.SvcName,
+	mock.EXPECT().CreateService(gomock.Any(), test.HttpNsName, test.SvcName).Return(nil).Times(1)
+	mock.EXPECT().RegisterEndpoints(gomock.Any(), test.HttpNsName, test.SvcName,
 		[]*model.Endpoint{test.GetTestEndpoint1()}).Return(nil).Times(1)
 
 	reconciler := getServiceExportReconciler(t, mock, fakeClient)
 
 	request := ctrl.Request{
 		NamespacedName: types.NamespacedName{
-			Namespace: test.NsName,
+			Namespace: test.HttpNsName,
 			Name:      test.SvcName,
 		},
 	}
@@ -66,7 +66,7 @@ func TestServiceExportReconciler_Reconcile_NewServiceExport(t *testing.T) {
 	assert.Equal(t, ctrl.Result{}, got, "Result should be empty")
 
 	serviceExport := &v1alpha1.ServiceExport{}
-	err = fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: test.NsName, Name: test.SvcName}, serviceExport)
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: test.HttpNsName, Name: test.SvcName}, serviceExport)
 	assert.NoError(t, err)
 	assert.Contains(t, serviceExport.Finalizers, ServiceExportFinalizer, "Finalizer added to the service export")
 }
@@ -87,15 +87,15 @@ func TestServiceExportReconciler_Reconcile_ExistingServiceExport(t *testing.T) {
 	mock := cloudmapMock.NewMockServiceDiscoveryClient(mockController)
 
 	// GetService from Cloudmap returns endpoint1 and endpoint2
-	mock.EXPECT().GetService(gomock.Any(), test.NsName, test.SvcName).
+	mock.EXPECT().GetService(gomock.Any(), test.HttpNsName, test.SvcName).
 		Return(test.GetTestService(), nil)
 	// call to delete the endpoint not present in the k8s cluster
-	mock.EXPECT().DeleteEndpoints(gomock.Any(), test.NsName, test.SvcName,
+	mock.EXPECT().DeleteEndpoints(gomock.Any(), test.HttpNsName, test.SvcName,
 		[]*model.Endpoint{test.GetTestEndpoint2()}).Return(nil).Times(1)
 
 	request := ctrl.Request{
 		NamespacedName: types.NamespacedName{
-			Namespace: test.NsName,
+			Namespace: test.HttpNsName,
 			Name:      test.SvcName,
 		},
 	}
@@ -110,7 +110,7 @@ func TestServiceExportReconciler_Reconcile_ExistingServiceExport(t *testing.T) {
 	assert.Equal(t, ctrl.Result{}, got, "Result should be empty")
 
 	serviceExport := &v1alpha1.ServiceExport{}
-	err = fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: test.NsName, Name: test.SvcName}, serviceExport)
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: test.HttpNsName, Name: test.SvcName}, serviceExport)
 	assert.NoError(t, err)
 	assert.Contains(t, serviceExport.Finalizers, ServiceExportFinalizer, "Finalizer added to the service export")
 }
@@ -134,15 +134,15 @@ func TestServiceExportReconciler_Reconcile_DeleteExistingService(t *testing.T) {
 	mock := cloudmapMock.NewMockServiceDiscoveryClient(mockController)
 
 	// GetService from Cloudmap returns endpoint1 and endpoint2
-	mock.EXPECT().GetService(gomock.Any(), test.NsName, test.SvcName).
+	mock.EXPECT().GetService(gomock.Any(), test.HttpNsName, test.SvcName).
 		Return(test.GetTestService(), nil)
 	// call to delete the endpoint in the cloudmap
-	mock.EXPECT().DeleteEndpoints(gomock.Any(), test.NsName, test.SvcName,
+	mock.EXPECT().DeleteEndpoints(gomock.Any(), test.HttpNsName, test.SvcName,
 		[]*model.Endpoint{test.GetTestEndpoint1(), test.GetTestEndpoint2()}).Return(nil).Times(1)
 
 	request := ctrl.Request{
 		NamespacedName: types.NamespacedName{
-			Namespace: test.NsName,
+			Namespace: test.HttpNsName,
 			Name:      test.SvcName,
 		},
 	}
@@ -154,7 +154,7 @@ func TestServiceExportReconciler_Reconcile_DeleteExistingService(t *testing.T) {
 	assert.Equal(t, ctrl.Result{}, got, "Result should be empty")
 
 	serviceExport := &v1alpha1.ServiceExport{}
-	err = fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: test.NsName, Name: test.SvcName}, serviceExport)
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: test.HttpNsName, Name: test.SvcName}, serviceExport)
 	assert.NoError(t, err)
 	assert.Empty(t, serviceExport.Finalizers, "Finalizer removed from the service export")
 }

--- a/pkg/controllers/utils_test.go
+++ b/pkg/controllers/utils_test.go
@@ -466,9 +466,9 @@ func TestCreateServiceImportStruct(t *testing.T) {
 			},
 			want: v1alpha1.ServiceImport{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace:   test.NsName,
+					Namespace:   test.HttpNsName,
 					Name:        test.SvcName,
-					Annotations: map[string]string{DerivedServiceAnnotation: DerivedName(test.NsName, test.SvcName)},
+					Annotations: map[string]string{DerivedServiceAnnotation: DerivedName(test.HttpNsName, test.SvcName)},
 				},
 				Spec: v1alpha1.ServiceImportSpec{
 					IPs:  []string{},
@@ -483,7 +483,7 @@ func TestCreateServiceImportStruct(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := CreateServiceImportStruct(test.NsName, test.SvcName, tt.args.servicePorts); !reflect.DeepEqual(*got, tt.want) {
+			if got := CreateServiceImportStruct(test.HttpNsName, test.SvcName, tt.args.servicePorts); !reflect.DeepEqual(*got, tt.want) {
 				t.Errorf("CreateServiceImportStruct() = %v, want %v", got, tt.want)
 			}
 		})

--- a/test/test-constants.go
+++ b/test/test-constants.go
@@ -7,8 +7,10 @@ import (
 )
 
 const (
-	NsName          = "ns-name"
-	NsId            = "ns-id"
+	HttpNsName      = "http-ns-name"
+	DnsNsName       = "dns-ns-name"
+	HttpNsId        = "http-ns-id"
+	DnsNsId         = "dns-ns-id"
 	SvcName         = "svc-name"
 	SvcId           = "svc-id"
 	EndptId1        = "tcp-192_168_0_1-1"
@@ -34,23 +36,23 @@ const (
 
 func GetTestHttpNamespace() *model.Namespace {
 	return &model.Namespace{
-		Id:   NsId,
-		Name: NsName,
+		Id:   HttpNsId,
+		Name: HttpNsName,
 		Type: model.HttpNamespaceType,
 	}
 }
 
 func GetTestDnsNamespace() *model.Namespace {
 	return &model.Namespace{
-		Id:   NsId,
-		Name: NsName,
+		Id:   DnsNsId,
+		Name: DnsNsName,
 		Type: model.DnsPrivateNamespaceType,
 	}
 }
 
 func GetTestService() *model.Service {
 	return &model.Service{
-		Namespace: NsName,
+		Namespace: HttpNsName,
 		Name:      SvcName,
 		Endpoints: []*model.Endpoint{GetTestEndpoint1(), GetTestEndpoint2()},
 	}
@@ -58,7 +60,7 @@ func GetTestService() *model.Service {
 
 func GetTestServiceWithEndpoint(endpoints []*model.Endpoint) *model.Service {
 	return &model.Service{
-		Namespace: NsName,
+		Namespace: HttpNsName,
 		Name:      SvcName,
 		Endpoints: endpoints,
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Separating http and dns namespace test constants to support more accurate testing of multiple values from api.
Eventually all http/dns concerns should be delegated to `pkg/cloudmap/internal` to support multiple service discovery clients.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
