### PR TITLE
Cache namespace and service maps

### DIFF
--- a/integration/janitor/janitor_test.go
+++ b/integration/janitor/janitor_test.go
@@ -28,10 +28,10 @@ func TestCleanupHappyCase(t *testing.T) {
 	tj := getTestJanitor(t)
 	defer tj.close()
 
-	tj.mockApi.EXPECT().ListNamespaces(context.TODO()).
-		Return([]*model.Namespace{{Id: test.HttpNsId, Name: test.HttpNsName}}, nil)
-	tj.mockApi.EXPECT().ListServices(context.TODO(), test.HttpNsId).
-		Return([]*model.Resource{{Id: test.SvcId, Name: test.SvcName}}, nil)
+	tj.mockApi.EXPECT().GetNamespaceMap(context.TODO()).
+		Return(map[string]*model.Namespace{test.HttpNsName: test.GetTestHttpNamespace()}, nil)
+	tj.mockApi.EXPECT().GetServiceIdMap(context.TODO(), test.HttpNsId).
+		Return(map[string]string{test.SvcName: test.SvcId}, nil)
 	tj.mockApi.EXPECT().DiscoverInstances(context.TODO(), test.HttpNsName, test.SvcName).
 		Return([]types.HttpInstanceSummary{{InstanceId: aws.String(test.EndptId1)}}, nil)
 
@@ -54,8 +54,8 @@ func TestCleanupNothingToClean(t *testing.T) {
 	tj := getTestJanitor(t)
 	defer tj.close()
 
-	tj.mockApi.EXPECT().ListNamespaces(context.TODO()).
-		Return([]*model.Namespace{}, nil)
+	tj.mockApi.EXPECT().GetNamespaceMap(context.TODO()).
+		Return(map[string]*model.Namespace{}, nil)
 
 	tj.janitor.Cleanup(context.TODO(), test.HttpNsName)
 	assert.False(t, *tj.failed)

--- a/pkg/cloudmap/api_test.go
+++ b/pkg/cloudmap/api_test.go
@@ -8,7 +8,6 @@ import (
 
 	cloudmapMock "github.com/aws/aws-cloud-map-mcs-controller-for-k8s/mocks/pkg/cloudmap"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/common"
-	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/test"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	sd "github.com/aws/aws-sdk-go-v2/service/servicediscovery"
@@ -23,7 +22,7 @@ func TestNewServiceDiscoveryApi(t *testing.T) {
 	assert.NotNil(t, sdc)
 }
 
-func TestServiceDiscoveryApi_ListNamespaces_HappyCase(t *testing.T) {
+func TestServiceDiscoveryApi_GetNamespaceMap_HappyCase(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
@@ -39,12 +38,13 @@ func TestServiceDiscoveryApi_ListNamespaces_HappyCase(t *testing.T) {
 	awsFacade.EXPECT().ListNamespaces(context.TODO(), &sd.ListNamespacesInput{}).
 		Return(&sd.ListNamespacesOutput{Namespaces: []types.NamespaceSummary{ns}}, nil)
 
-	namespaces, _ := sdApi.ListNamespaces(context.TODO())
+	namespaces, err := sdApi.GetNamespaceMap(context.TODO())
+	assert.Nil(t, err, "No error for happy case")
 	assert.True(t, len(namespaces) == 1)
-	assert.Equal(t, test.GetTestDnsNamespace(), namespaces[0], "No error for happy case")
+	assert.Equal(t, test.GetTestDnsNamespace(), namespaces[test.DnsNsName])
 }
 
-func TestServiceDiscoveryApi_ListNamespaces_SkipPublicDNSNotSupported(t *testing.T) {
+func TestServiceDiscoveryApi_GetNamespaceMap_SkipPublicDNSNotSupported(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
@@ -60,11 +60,12 @@ func TestServiceDiscoveryApi_ListNamespaces_SkipPublicDNSNotSupported(t *testing
 	awsFacade.EXPECT().ListNamespaces(context.TODO(), &sd.ListNamespacesInput{}).
 		Return(&sd.ListNamespacesOutput{Namespaces: []types.NamespaceSummary{ns}}, nil)
 
-	namespaces, _ := sdApi.ListNamespaces(context.TODO())
-	assert.True(t, len(namespaces) == 0, "Successfully skipped DNS_PUBLIC from the output")
+	namespaces, err := sdApi.GetNamespaceMap(context.TODO())
+	assert.Nil(t, err, "No error for happy case")
+	assert.Empty(t, namespaces, "Successfully skipped DNS_PUBLIC from the output")
 }
 
-func TestServiceDiscoveryApi_ListServices_HappyCase(t *testing.T) {
+func TestServiceDiscoveryApi_GetServiceIdMap_HappyCase(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
@@ -81,10 +82,10 @@ func TestServiceDiscoveryApi_ListServices_HappyCase(t *testing.T) {
 			{Id: aws.String(test.SvcId), Name: aws.String(test.SvcName)},
 		}}, nil)
 
-	svcs, err := sdApi.ListServices(context.TODO(), test.HttpNsId)
+	svcs, err := sdApi.GetServiceIdMap(context.TODO(), test.HttpNsId)
 	assert.Nil(t, err, "No error for happy case")
 	assert.True(t, len(svcs) == 1)
-	assert.Equal(t, svcs[0], &model.Resource{Id: test.SvcId, Name: test.SvcName})
+	assert.Equal(t, svcs[test.SvcName], test.SvcId)
 }
 
 func TestServiceDiscoveryApi_DiscoverInstances_HappyCase(t *testing.T) {
@@ -184,7 +185,8 @@ func TestServiceDiscoveryApi_CreateService_CreateForHttpNamespace(t *testing.T) 
 			},
 		}, nil)
 
-	retSvcId, _ := sdApi.CreateService(context.TODO(), *test.GetTestHttpNamespace(), svcName)
+	retSvcId, err := sdApi.CreateService(context.TODO(), *test.GetTestHttpNamespace(), svcName)
+	assert.Nil(t, err)
 	assert.Equal(t, svcId, retSvcId, "Successfully created service")
 }
 
@@ -212,7 +214,8 @@ func TestServiceDiscoveryApi_CreateService_CreateForDnsNamespace(t *testing.T) {
 			},
 		}, nil)
 
-	retSvcId, _ := sdApi.CreateService(context.TODO(), *test.GetTestDnsNamespace(), svcName)
+	retSvcId, err := sdApi.CreateService(context.TODO(), *test.GetTestDnsNamespace(), svcName)
+	assert.Nil(t, err)
 	assert.Equal(t, svcId, retSvcId, "Successfully created service")
 }
 

--- a/pkg/cloudmap/cache_test.go
+++ b/pkg/cloudmap/cache_test.go
@@ -4,9 +4,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/common"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/model"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/test"
+	testing2 "github.com/go-logr/logr/testing"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/cache"
 )
 
 func TestNewServiceDiscoveryClientCache(t *testing.T) {
@@ -35,70 +38,84 @@ func TestNewDefaultServiceDiscoveryClientCache(t *testing.T) {
 	assert.Equal(t, defaultEndptTTL, sdc.config.EndptTTL)
 }
 
-func TestServiceDiscoveryClientCacheGetNamespace_Found(t *testing.T) {
+func TestServiceDiscoveryClientCacheGetNamespaceMap_Found(t *testing.T) {
 	sdc := NewDefaultServiceDiscoveryClientCache()
-	sdc.CacheNamespace(test.GetTestHttpNamespace())
+	sdc.CacheNamespaceMap(map[string]*model.Namespace{
+		test.HttpNsName: test.GetTestHttpNamespace(),
+	})
 
-	ns, found := sdc.GetNamespace(test.HttpNsName)
+	nsMap, found := sdc.GetNamespaceMap()
 	assert.True(t, found)
-	assert.Equal(t, test.GetTestHttpNamespace(), ns)
+	assert.Equal(t, test.GetTestHttpNamespace(), nsMap[test.HttpNsName])
 }
 
-func TestServiceDiscoveryClientCacheGetNamespace_NotFound(t *testing.T) {
+func TestServiceDiscoveryClientCacheGetNamespaceMap_NotFound(t *testing.T) {
 	sdc := NewDefaultServiceDiscoveryClientCache()
 
-	ns, found := sdc.GetNamespace(test.HttpNsName)
+	nsMap, found := sdc.GetNamespaceMap()
 	assert.False(t, found)
-	assert.Nil(t, ns)
+	assert.Nil(t, nsMap)
 }
 
-func TestServiceDiscoveryClientCacheGetNamespace_Nil(t *testing.T) {
-	sdc := NewDefaultServiceDiscoveryClientCache()
-	sdc.CacheNilNamespace(test.HttpNsName)
+func TestServiceDiscoveryClientCacheGetNamespaceMap_Corrupt(t *testing.T) {
+	sdc := getCacheImpl(t)
+	sdc.cache.Add(nsKey, &model.Plan{}, time.Minute)
 
-	ns, found := sdc.GetNamespace(test.HttpNsName)
+	nsMap, found := sdc.GetNamespaceMap()
+	assert.False(t, found)
+	assert.Nil(t, nsMap)
+}
+
+func TestServiceDiscoveryClientEvictNamespaceMap(t *testing.T) {
+	sdc := NewDefaultServiceDiscoveryClientCache()
+	sdc.CacheNamespaceMap(map[string]*model.Namespace{
+		test.HttpNsName: test.GetTestHttpNamespace(),
+	})
+	sdc.EvictNamespaceMap()
+
+	nsMap, found := sdc.GetNamespaceMap()
+	assert.False(t, found)
+	assert.Nil(t, nsMap)
+}
+
+func TestServiceDiscoveryClientCacheGetServiceIdMap_Found(t *testing.T) {
+	sdc := NewDefaultServiceDiscoveryClientCache()
+	sdc.CacheServiceIdMap(test.HttpNsName, map[string]string{
+		test.SvcName: test.SvcId,
+	})
+
+	svcIdMap, found := sdc.GetServiceIdMap(test.HttpNsName)
 	assert.True(t, found)
-	assert.Nil(t, ns)
+	assert.Equal(t, test.SvcId, svcIdMap[test.SvcName])
 }
 
-func TestServiceDiscoveryClientCacheGetNamespace_Corrupt(t *testing.T) {
-	sdc, ok := NewDefaultServiceDiscoveryClientCache().(*sdCache)
-	if !ok {
-		t.Fatalf("failed to create cache")
-	}
-	sdc.cache.Add(sdc.buildNsKey(test.HttpNsName), &model.Resource{}, time.Minute)
-
-	ns, found := sdc.GetNamespace(test.HttpNsName)
-	assert.False(t, found)
-	assert.Nil(t, ns)
-}
-
-func TestServiceDiscoveryClientCacheGetServiceId_Found(t *testing.T) {
-	sdc := NewDefaultServiceDiscoveryClientCache()
-	sdc.CacheServiceId(test.HttpNsName, test.SvcName, test.SvcId)
-
-	svcId, found := sdc.GetServiceId(test.HttpNsName, test.SvcName)
-	assert.True(t, found)
-	assert.Equal(t, test.SvcId, svcId)
-}
-
-func TestServiceDiscoveryClientCacheGetServiceId_NotFound(t *testing.T) {
+func TestServiceDiscoveryClientCacheGetServiceIdMap_NotFound(t *testing.T) {
 	sdc := NewDefaultServiceDiscoveryClientCache()
 
-	svcId, found := sdc.GetServiceId(test.HttpNsName, test.SvcName)
+	svcIdMap, found := sdc.GetServiceIdMap(test.HttpNsName)
 	assert.False(t, found)
-	assert.Empty(t, svcId)
+	assert.Empty(t, svcIdMap)
 }
 
-func TestServiceDiscoveryClientCacheGetServiceId_Corrupt(t *testing.T) {
-	sdc, ok := NewDefaultServiceDiscoveryClientCache().(*sdCache)
-	if !ok {
-		t.Fatalf("failed to create cache")
-	}
-	sdc.cache.Add(sdc.buildSvcKey(test.HttpNsName, test.SvcName), &model.Resource{}, time.Minute)
-	svcId, found := sdc.GetServiceId(test.HttpNsName, test.SvcName)
+func TestServiceDiscoveryClientCacheGetServiceIdMap_Corrupt(t *testing.T) {
+	sdc := getCacheImpl(t)
+	sdc.cache.Add(sdc.buildSvcKey(test.HttpNsName), &model.Plan{}, time.Minute)
+
+	svcIdMap, found := sdc.GetServiceIdMap(test.HttpNsName)
 	assert.False(t, found)
-	assert.Empty(t, svcId)
+	assert.Empty(t, svcIdMap)
+}
+
+func TestServiceDiscoveryClientEvictServiceIdMap(t *testing.T) {
+	sdc := NewDefaultServiceDiscoveryClientCache()
+	sdc.CacheServiceIdMap(test.HttpNsName, map[string]string{
+		test.SvcName: test.SvcId,
+	})
+	sdc.EvictServiceIdMap(test.HttpNsName)
+
+	svcIdMap, found := sdc.GetServiceIdMap(test.HttpNsName)
+	assert.False(t, found)
+	assert.Empty(t, svcIdMap)
 }
 
 func TestServiceDiscoveryClientCacheGetEndpoints_Found(t *testing.T) {
@@ -119,12 +136,9 @@ func TestServiceDiscoveryClientCacheGetEndpoints_NotFound(t *testing.T) {
 }
 
 func TestServiceDiscoveryClientCacheGetEndpoints_Corrupt(t *testing.T) {
-	sdc, ok := NewDefaultServiceDiscoveryClientCache().(*sdCache)
-	if !ok {
-		t.Fatalf("failed to create cache")
-	}
+	sdc := getCacheImpl(t)
+	sdc.cache.Add(sdc.buildEndptsKey(test.HttpNsName, test.SvcName), &model.Plan{}, time.Minute)
 
-	sdc.cache.Add(sdc.buildEndptsKey(test.HttpNsName, test.SvcName), &model.Resource{}, time.Minute)
 	endpts, found := sdc.GetEndpoints(test.HttpNsName, test.SvcName)
 	assert.False(t, found)
 	assert.Nil(t, endpts)
@@ -138,4 +152,11 @@ func TestServiceDiscoveryClientEvictEndpoints(t *testing.T) {
 	endpts, found := sdc.GetEndpoints(test.HttpNsName, test.SvcName)
 	assert.False(t, found)
 	assert.Nil(t, endpts)
+}
+
+func getCacheImpl(t *testing.T) sdCache {
+	return sdCache{
+		log:   common.NewLoggerWithLogr(testing2.TestLogger{T: t}),
+		cache: cache.NewLRUExpireCache(defaultCacheSize),
+	}
 }

--- a/pkg/controllers/cloudmap_controller.go
+++ b/pkg/controllers/cloudmap_controller.go
@@ -55,11 +55,9 @@ func (r *CloudMapReconciler) Start(ctx context.Context) error {
 func (r *CloudMapReconciler) Reconcile(ctx context.Context) error {
 	namespaces := v1.NamespaceList{}
 	if err := r.Client.List(ctx, &namespaces); err != nil {
-		r.Log.Error(err, "unable to list namespaces")
+		r.Log.Error(err, "unable to list cluster namespaces")
 		return err
 	}
-
-	//TODO: Fetch list of namespaces from Cloudmap and only reconcile the intersection
 
 	for _, ns := range namespaces.Items {
 		if err := r.reconcileNamespace(ctx, ns.Name); err != nil {

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -10,12 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/servicediscovery/types"
 )
 
-// Resource encapsulates a ID/name pair.
-type Resource struct {
-	Id   string
-	Name string
-}
-
 const (
 	HttpNamespaceType       NamespaceType = "HTTP"
 	DnsPrivateNamespaceType NamespaceType = "DNS_PRIVATE"

--- a/test/test-constants.go
+++ b/test/test-constants.go
@@ -25,7 +25,7 @@ const (
 	ServicePortStr1 = "11"
 	Port2           = 2
 	PortStr2        = "2"
-	PortName2       = "http"
+	PortName2       = "https"
 	Protocol2       = "UDP"
 	ServicePort2    = 22
 	ServicePortStr2 = "22"


### PR DESCRIPTION
*Issue #, if available:*
#65

*Description of changes:*
Use maps in service and namespace cache.
This will reduce the number of calls we need to make to Cloud Map and avoid throttling. This allows us to reduce our namespace and service cache TTL and import changes faster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
