### PR TITLE
Add ServiceType to Cloud Map and Endpoints

### DIFF
--- a/integration/shared/scenarios/export_service.go
+++ b/integration/shared/scenarios/export_service.go
@@ -58,6 +58,7 @@ func NewExportServiceScenario(cfg *aws.Config, nsName string, svcName string, po
 				Protocol:   string(v1.ProtocolTCP),
 			},
 			EndpointPort: endpointPort,
+			ServiceType:  model.ClusterIPType, // in scenario, we assume ClusterIP type
 			Attributes:   make(map[string]string),
 		})
 	}

--- a/integration/shared/scenarios/export_service.go
+++ b/integration/shared/scenarios/export_service.go
@@ -58,7 +58,7 @@ func NewExportServiceScenario(cfg *aws.Config, nsName string, svcName string, po
 				Protocol:   string(v1.ProtocolTCP),
 			},
 			EndpointPort: endpointPort,
-			ServiceType:  model.ClusterIPType, // in scenario, we assume ClusterIP type
+			ServiceType:  model.ClusterSetIPType, // in scenario, we assume ClusterSetIP type
 			Attributes:   make(map[string]string),
 		})
 	}

--- a/pkg/cloudmap/client_test.go
+++ b/pkg/cloudmap/client_test.go
@@ -291,6 +291,7 @@ func TestServiceDiscoveryClient_RegisterEndpoints(t *testing.T) {
 		model.ServicePortAttr:       test.ServicePortStr1,
 		model.ServiceProtocolAttr:   test.Protocol1,
 		model.ServiceTargetPortAttr: test.PortStr1,
+		model.ServiceTypeAttr:       test.SvcType,
 	}
 	attrs2 := map[string]string{
 		model.EndpointIpv4Attr:      test.EndptIp2,
@@ -301,6 +302,7 @@ func TestServiceDiscoveryClient_RegisterEndpoints(t *testing.T) {
 		model.ServicePortAttr:       test.ServicePortStr2,
 		model.ServiceProtocolAttr:   test.Protocol2,
 		model.ServiceTargetPortAttr: test.PortStr2,
+		model.ServiceTypeAttr:       test.SvcType,
 	}
 
 	tc.mockApi.EXPECT().RegisterInstance(context.TODO(), test.SvcId, test.EndptId1, attrs1).
@@ -370,6 +372,7 @@ func getHttpInstanceSummaryForTest() []types.HttpInstanceSummary {
 				model.ServicePortAttr:       test.ServicePortStr1,
 				model.ServiceProtocolAttr:   test.Protocol1,
 				model.ServiceTargetPortAttr: test.PortStr1,
+				model.ServiceTypeAttr:       test.SvcType,
 			},
 		},
 		{
@@ -383,6 +386,7 @@ func getHttpInstanceSummaryForTest() []types.HttpInstanceSummary {
 				model.ServicePortAttr:       test.ServicePortStr2,
 				model.ServiceProtocolAttr:   test.Protocol2,
 				model.ServiceTargetPortAttr: test.PortStr2,
+				model.ServiceTypeAttr:       test.SvcType,
 			},
 		},
 	}

--- a/pkg/controllers/multicluster/serviceexport_controller.go
+++ b/pkg/controllers/multicluster/serviceexport_controller.go
@@ -225,6 +225,14 @@ func (r *ServiceExportReconciler) extractEndpoints(ctx context.Context, svc *v1.
 		return nil, err
 	}
 
+	// TODO: make const or enum?
+	var serviceType string
+	if svc.Spec.ClusterIP == "None" {
+		serviceType = "Headless"
+	} else {
+		serviceType = "ClusterIP"
+	}
+
 	servicePortMap := make(map[string]model.Port)
 	for _, svcPort := range svc.Spec.Ports {
 		servicePortMap[svcPort.Name] = ServicePortToPort(svcPort)
@@ -249,6 +257,7 @@ func (r *ServiceExportReconciler) extractEndpoints(ctx context.Context, svc *v1.
 						IP:           IP,
 						EndpointPort: port,
 						ServicePort:  servicePortMap[*endpointPort.Name],
+						ServiceType:  serviceType,
 						Attributes:   attributes,
 					})
 				}

--- a/pkg/controllers/multicluster/serviceexport_controller.go
+++ b/pkg/controllers/multicluster/serviceexport_controller.go
@@ -225,12 +225,11 @@ func (r *ServiceExportReconciler) extractEndpoints(ctx context.Context, svc *v1.
 		return nil, err
 	}
 
-	// TODO: make const or enum?
-	var serviceType string
+	var serviceType model.ServiceType
 	if svc.Spec.ClusterIP == "None" {
-		serviceType = "Headless"
+		serviceType = model.HeadlessType
 	} else {
-		serviceType = "ClusterIP"
+		serviceType = model.ClusterIPType
 	}
 
 	servicePortMap := make(map[string]model.Port)

--- a/pkg/controllers/multicluster/serviceexport_controller.go
+++ b/pkg/controllers/multicluster/serviceexport_controller.go
@@ -225,12 +225,7 @@ func (r *ServiceExportReconciler) extractEndpoints(ctx context.Context, svc *v1.
 		return nil, err
 	}
 
-	var serviceType model.ServiceType
-	if svc.Spec.ClusterIP == "None" {
-		serviceType = model.HeadlessType
-	} else {
-		serviceType = model.ClusterIPType
-	}
+	serviceType := ExtractServiceType(svc)
 
 	servicePortMap := make(map[string]model.Port)
 	for _, svcPort := range svc.Spec.Ports {

--- a/pkg/controllers/multicluster/utils.go
+++ b/pkg/controllers/multicluster/utils.go
@@ -233,5 +233,5 @@ func ExtractServiceType(svc *v1.Service) model.ServiceType {
 		return model.HeadlessType
 	}
 
-	return model.ClusterIPType
+	return model.ClusterSetIPType
 }

--- a/pkg/controllers/multicluster/utils.go
+++ b/pkg/controllers/multicluster/utils.go
@@ -229,12 +229,9 @@ func CreateEndpointSliceStruct(svc *v1.Service, svcImportName string) *discovery
 
 // ExtractServiceType finds the ServiceType of a given service as Headless/ClusterSetIP
 func ExtractServiceType(svc *v1.Service) model.ServiceType {
-	var serviceType model.ServiceType
 	if svc.Spec.ClusterIP == "None" {
-		serviceType = model.HeadlessType
-	} else {
-		serviceType = model.ClusterIPType
+		return model.HeadlessType
 	}
 
-	return serviceType
+	return model.ClusterIPType
 }

--- a/pkg/controllers/multicluster/utils.go
+++ b/pkg/controllers/multicluster/utils.go
@@ -226,3 +226,15 @@ func CreateEndpointSliceStruct(svc *v1.Service, svcImportName string) *discovery
 		AddressType: discovery.AddressTypeIPv4,
 	}
 }
+
+// ExtractServiceType finds the ServiceType of a given service as Headless/ClusterSetIP
+func ExtractServiceType(svc *v1.Service) model.ServiceType {
+	var serviceType model.ServiceType
+	if svc.Spec.ClusterIP == "None" {
+		serviceType = model.HeadlessType
+	} else {
+		serviceType = model.ClusterIPType
+	}
+
+	return serviceType
+}

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -95,11 +95,11 @@ func NewEndpointFromInstance(inst *types.HttpInstanceSummary) (endpointPtr *Endp
 		return nil, err
 	}
 
-	var serviceTypeStr string
-	if serviceTypeStr, err = removeStringAttr(attributes, ServiceTypeAttr); err != nil {
+	if serviceTypeStr, err := removeStringAttr(attributes, ServiceTypeAttr); err == nil {
+		endpoint.ServiceType = ServiceType(serviceTypeStr)
+	} else {
 		return nil, err
 	}
-	endpoint.ServiceType = ServiceType(serviceTypeStr)
 
 	// Add the remaining attributes
 	endpoint.Attributes = attributes

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -39,6 +39,7 @@ type Endpoint struct {
 	IP           string
 	EndpointPort Port
 	ServicePort  Port
+	ServiceType  string
 	Attributes   map[string]string
 }
 
@@ -60,6 +61,7 @@ const (
 	ServicePortAttr       = "SERVICE_PORT"
 	ServiceTargetPortAttr = "SERVICE_TARGET_PORT"
 	ServiceProtocolAttr   = "SERVICE_PROTOCOL"
+	ServiceTypeAttr       = "SERVICE_TYPE"
 )
 
 // NewEndpointFromInstance converts a Cloud Map HttpInstanceSummary to an endpoint.
@@ -73,7 +75,7 @@ func NewEndpointFromInstance(inst *types.HttpInstanceSummary) (endpointPtr *Endp
 		attributes[key] = value
 	}
 
-	// Remove and set the IP, Port, Port
+	// Remove and set the IP, Port, Port, ServiceType
 	if endpoint.IP, err = removeStringAttr(attributes, EndpointIpv4Attr); err != nil {
 		return nil, err
 	}
@@ -83,6 +85,10 @@ func NewEndpointFromInstance(inst *types.HttpInstanceSummary) (endpointPtr *Endp
 	}
 
 	if endpoint.ServicePort, err = servicePortFromAttr(attributes); err != nil {
+		return nil, err
+	}
+
+	if endpoint.ServiceType, err = removeStringAttr(attributes, ServiceTypeAttr); err != nil {
 		return nil, err
 	}
 
@@ -156,6 +162,7 @@ func (e *Endpoint) GetCloudMapAttributes() map[string]string {
 	attrs[ServicePortAttr] = strconv.Itoa(int(e.ServicePort.Port))
 	attrs[ServiceTargetPortAttr] = e.ServicePort.TargetPort
 	attrs[ServiceProtocolAttr] = e.ServicePort.Protocol
+	attrs[ServiceTypeAttr] = e.ServiceType
 
 	for key, val := range e.Attributes {
 		attrs[key] = val

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -35,7 +35,7 @@ type Service struct {
 
 const (
 	HeadlessType  ServiceType = "Headless"
-	ClusterIPType ServiceType = "ClusterIP"
+	ClusterIPType ServiceType = "ClusterSetIP"
 )
 
 type ServiceType string
@@ -211,16 +211,7 @@ func EndpointIdFromIPAddressAndPort(address string, port Port) string {
 
 // Gives string representation for ServiceType
 func (serviceType ServiceType) String() string {
-	serviceTypes := [...]string{"Headless", "ClusterIP"}
-	// returning string representation
-	x := string(serviceType)
-	for _, v := range serviceTypes {
-		if v == x {
-			return x
-		}
-	}
-
-	return "" // empty string if unknown
+	return string(serviceType)
 }
 
 func ConvertNamespaceType(nsType types.NamespaceType) (namespaceType NamespaceType) {

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -35,7 +35,7 @@ type Service struct {
 
 const (
 	HeadlessType  ServiceType = "Headless"
-	ClusterIPType ServiceType = "ClusterSetIP"
+	ClusterIPType ServiceType = "ClusterIP"
 )
 
 type ServiceType string
@@ -82,7 +82,7 @@ func NewEndpointFromInstance(inst *types.HttpInstanceSummary) (endpointPtr *Endp
 		attributes[key] = value
 	}
 
-	// Remove and set the IP, Port, Port, ServiceType
+	// Remove and set the IP, Port, Service Port, ServiceType
 	if endpoint.IP, err = removeStringAttr(attributes, EndpointIpv4Attr); err != nil {
 		return nil, err
 	}

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -34,8 +34,8 @@ type Service struct {
 }
 
 const (
-	HeadlessType  ServiceType = "Headless"
-	ClusterIPType ServiceType = "ClusterIP"
+	HeadlessType     ServiceType = "Headless"
+	ClusterSetIPType ServiceType = "ClusterSetIP"
 )
 
 type ServiceType string
@@ -72,7 +72,7 @@ const (
 )
 
 // NewEndpointFromInstance converts a Cloud Map HttpInstanceSummary to an endpoint.
-func NewEndpointFromInstance(inst *types.HttpInstanceSummary) (endpointPtr *Endpoint, err error) {
+func NewEndpointFromInstance(inst *types.HttpInstanceSummary) (*Endpoint, error) {
 	endpoint := Endpoint{
 		Id:         *inst.InstanceId,
 		Attributes: make(map[string]string),
@@ -83,17 +83,23 @@ func NewEndpointFromInstance(inst *types.HttpInstanceSummary) (endpointPtr *Endp
 	}
 
 	// Remove and set the IP, Port, Service Port, ServiceType
-	if endpoint.IP, err = removeStringAttr(attributes, EndpointIpv4Attr); err != nil {
+	ip, err := removeStringAttr(attributes, EndpointIpv4Attr)
+	if err != nil {
 		return nil, err
 	}
+	endpoint.IP = ip
 
-	if endpoint.EndpointPort, err = endpointPortFromAttr(attributes); err != nil {
+	endpointPort, err := endpointPortFromAttr(attributes)
+	if err != nil {
 		return nil, err
 	}
+	endpoint.EndpointPort = endpointPort
 
-	if endpoint.ServicePort, err = servicePortFromAttr(attributes); err != nil {
+	servicePort, err := servicePortFromAttr(attributes)
+	if err != nil {
 		return nil, err
 	}
+	endpoint.ServicePort = servicePort
 
 	if serviceTypeStr, err := removeStringAttr(attributes, ServiceTypeAttr); err == nil {
 		endpoint.ServiceType = ServiceType(serviceTypeStr)

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -95,23 +95,16 @@ func NewEndpointFromInstance(inst *types.HttpInstanceSummary) (endpointPtr *Endp
 		return nil, err
 	}
 
-	if endpoint.ServiceType, err = serviceTypeFromAttr(attributes); err != nil {
+	var serviceTypeStr string
+	if serviceTypeStr, err = removeStringAttr(attributes, ServiceTypeAttr); err != nil {
 		return nil, err
 	}
+	endpoint.ServiceType = ServiceType(serviceTypeStr)
 
 	// Add the remaining attributes
 	endpoint.Attributes = attributes
 
 	return &endpoint, err
-}
-
-func serviceTypeFromAttr(attributes map[string]string) (serviceType ServiceType, err error) {
-	var serviceTypeStr string
-	if serviceTypeStr, err = removeStringAttr(attributes, ServiceTypeAttr); err != nil {
-		return serviceType, err
-	}
-	serviceType = ServiceType(serviceTypeStr)
-	return serviceType, err
 }
 
 func endpointPortFromAttr(attributes map[string]string) (port Port, err error) {

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -101,11 +101,11 @@ func NewEndpointFromInstance(inst *types.HttpInstanceSummary) (*Endpoint, error)
 	}
 	endpoint.ServicePort = servicePort
 
-	if serviceTypeStr, err := removeStringAttr(attributes, ServiceTypeAttr); err == nil {
-		endpoint.ServiceType = ServiceType(serviceTypeStr)
-	} else {
+	serviceTypeStr, err := removeStringAttr(attributes, ServiceTypeAttr)
+	if err != nil {
 		return nil, err
 	}
+	endpoint.ServiceType = ServiceType(serviceTypeStr)
 
 	// Add the remaining attributes
 	endpoint.Attributes = attributes

--- a/pkg/model/types_test.go
+++ b/pkg/model/types_test.go
@@ -9,6 +9,7 @@ import (
 
 var instId = "my-instance"
 var ip = "192.168.0.1"
+var serviceType = "ClusterIP"
 
 func TestNewEndpointFromInstance(t *testing.T) {
 	tests := []struct {
@@ -30,6 +31,7 @@ func TestNewEndpointFromInstance(t *testing.T) {
 					ServiceProtocolAttr:   "TCP",
 					ServicePortAttr:       "65535",
 					ServiceTargetPortAttr: "80",
+					ServiceTypeAttr:       serviceType,
 					"custom-attr":         "custom-val",
 				},
 			},
@@ -47,6 +49,7 @@ func TestNewEndpointFromInstance(t *testing.T) {
 					TargetPort: "80",
 					Protocol:   "TCP",
 				},
+				ServiceType: serviceType,
 				Attributes: map[string]string{
 					"custom-attr": "custom-val",
 				},
@@ -65,6 +68,7 @@ func TestNewEndpointFromInstance(t *testing.T) {
 					ServiceProtocolAttr:   "TCP",
 					ServicePortAttr:       "99999",
 					ServiceTargetPortAttr: "80",
+					ServiceTypeAttr:       serviceType,
 					"custom-attr":         "custom-val",
 				},
 			},
@@ -92,6 +96,24 @@ func TestNewEndpointFromInstance(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "missing ServiceType",
+			inst: &types.HttpInstanceSummary{
+				InstanceId: &instId,
+				Attributes: map[string]string{
+					EndpointIpv4Attr:      ip,
+					EndpointPortAttr:      "80",
+					EndpointProtocolAttr:  "TCP",
+					EndpointPortNameAttr:  "http",
+					ServicePortNameAttr:   "http",
+					ServiceProtocolAttr:   "TCP",
+					ServicePortAttr:       "65535",
+					ServiceTargetPortAttr: "80",
+					"custom-attr":         "custom-val",
+				},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -113,6 +135,7 @@ func TestEndpoint_GetAttributes(t *testing.T) {
 		IP           string
 		EndpointPort Port
 		ServicePort  Port
+		ServiceType  string
 		Attributes   map[string]string
 	}
 	tests := []struct {
@@ -135,6 +158,7 @@ func TestEndpoint_GetAttributes(t *testing.T) {
 					TargetPort: "80",
 					Protocol:   "TCP",
 				},
+				ServiceType: serviceType,
 				Attributes: map[string]string{
 					"custom-attr": "custom-val",
 				},
@@ -148,6 +172,7 @@ func TestEndpoint_GetAttributes(t *testing.T) {
 				ServiceProtocolAttr:   "TCP",
 				ServicePortAttr:       "30",
 				ServiceTargetPortAttr: "80",
+				ServiceTypeAttr:       serviceType,
 				"custom-attr":         "custom-val",
 			},
 		},
@@ -159,6 +184,7 @@ func TestEndpoint_GetAttributes(t *testing.T) {
 				IP:           tt.fields.IP,
 				EndpointPort: tt.fields.EndpointPort,
 				ServicePort:  tt.fields.ServicePort,
+				ServiceType:  tt.fields.ServiceType,
 				Attributes:   tt.fields.Attributes,
 			}
 			if got := e.GetCloudMapAttributes(); !reflect.DeepEqual(got, tt.want) {

--- a/pkg/model/types_test.go
+++ b/pkg/model/types_test.go
@@ -49,7 +49,7 @@ func TestNewEndpointFromInstance(t *testing.T) {
 					TargetPort: "80",
 					Protocol:   "TCP",
 				},
-				ServiceType: serviceType,
+				ServiceType: ServiceType(serviceType),
 				Attributes: map[string]string{
 					"custom-attr": "custom-val",
 				},
@@ -135,7 +135,7 @@ func TestEndpoint_GetAttributes(t *testing.T) {
 		IP           string
 		EndpointPort Port
 		ServicePort  Port
-		ServiceType  string
+		ServiceType  ServiceType
 		Attributes   map[string]string
 	}
 	tests := []struct {
@@ -158,7 +158,7 @@ func TestEndpoint_GetAttributes(t *testing.T) {
 					TargetPort: "80",
 					Protocol:   "TCP",
 				},
-				ServiceType: serviceType,
+				ServiceType: ServiceType(serviceType),
 				Attributes: map[string]string{
 					"custom-attr": "custom-val",
 				},

--- a/pkg/model/types_test.go
+++ b/pkg/model/types_test.go
@@ -9,7 +9,7 @@ import (
 
 var instId = "my-instance"
 var ip = "192.168.0.1"
-var serviceType = "ClusterSetIP"
+var serviceType = ClusterIPType.String()
 
 func TestNewEndpointFromInstance(t *testing.T) {
 	tests := []struct {

--- a/pkg/model/types_test.go
+++ b/pkg/model/types_test.go
@@ -9,7 +9,7 @@ import (
 
 var instId = "my-instance"
 var ip = "192.168.0.1"
-var serviceType = ClusterIPType.String()
+var serviceType = ClusterSetIPType.String()
 
 func TestNewEndpointFromInstance(t *testing.T) {
 	tests := []struct {

--- a/pkg/model/types_test.go
+++ b/pkg/model/types_test.go
@@ -9,7 +9,7 @@ import (
 
 var instId = "my-instance"
 var ip = "192.168.0.1"
-var serviceType = "ClusterIP"
+var serviceType = "ClusterSetIP"
 
 func TestNewEndpointFromInstance(t *testing.T) {
 	tests := []struct {

--- a/samples/example-headless.yaml
+++ b/samples/example-headless.yaml
@@ -1,0 +1,11 @@
+kind: Service
+apiVersion: v1
+metadata:
+  namespace: example
+  name: my-service
+spec:
+  clusterIP: None
+  selector:
+    app: nginx
+  ports:
+    - port: 80

--- a/test/test-constants.go
+++ b/test/test-constants.go
@@ -32,6 +32,7 @@ const (
 	OpId1           = "operation-id-1"
 	OpId2           = "operation-id-2"
 	OpStart         = 1
+	SvcType         = "ClusterIP"
 )
 
 func GetTestHttpNamespace() *model.Namespace {
@@ -81,7 +82,8 @@ func GetTestEndpoint1() *model.Endpoint {
 			TargetPort: PortStr1,
 			Protocol:   Protocol1,
 		},
-		Attributes: make(map[string]string),
+		ServiceType: SvcType,
+		Attributes:  make(map[string]string),
 	}
 }
 
@@ -100,7 +102,8 @@ func GetTestEndpoint2() *model.Endpoint {
 			TargetPort: PortStr2,
 			Protocol:   Protocol2,
 		},
-		Attributes: make(map[string]string),
+		ServiceType: SvcType,
+		Attributes:  make(map[string]string),
 	}
 }
 

--- a/test/test-constants.go
+++ b/test/test-constants.go
@@ -32,7 +32,7 @@ const (
 	OpId1           = "operation-id-1"
 	OpId2           = "operation-id-2"
 	OpStart         = 1
-	SvcType         = "ClusterIP"
+	SvcType         = "ClusterSetIP"
 )
 
 func GetTestHttpNamespace() *model.Namespace {
@@ -82,7 +82,7 @@ func GetTestEndpoint1() *model.Endpoint {
 			TargetPort: PortStr1,
 			Protocol:   Protocol1,
 		},
-		ServiceType: model.ClusterIPType,
+		ServiceType: model.ClusterSetIPType,
 		Attributes:  make(map[string]string),
 	}
 }
@@ -102,7 +102,7 @@ func GetTestEndpoint2() *model.Endpoint {
 			TargetPort: PortStr2,
 			Protocol:   Protocol2,
 		},
-		ServiceType: model.ClusterIPType,
+		ServiceType: model.ClusterSetIPType,
 		Attributes:  make(map[string]string),
 	}
 }

--- a/test/test-constants.go
+++ b/test/test-constants.go
@@ -82,7 +82,7 @@ func GetTestEndpoint1() *model.Endpoint {
 			TargetPort: PortStr1,
 			Protocol:   Protocol1,
 		},
-		ServiceType: SvcType,
+		ServiceType: model.ClusterIPType,
 		Attributes:  make(map[string]string),
 	}
 }
@@ -102,7 +102,7 @@ func GetTestEndpoint2() *model.Endpoint {
 			TargetPort: PortStr2,
 			Protocol:   Protocol2,
 		},
-		ServiceType: SvcType,
+		ServiceType: model.ClusterIPType,
 		Attributes:  make(map[string]string),
 	}
 }

--- a/test/test-constants.go
+++ b/test/test-constants.go
@@ -32,7 +32,7 @@ const (
 	OpId1           = "operation-id-1"
 	OpId2           = "operation-id-2"
 	OpStart         = 1
-	SvcType         = "ClusterIP"
+	SvcType         = "ClusterSetIP"
 )
 
 func GetTestHttpNamespace() *model.Namespace {

--- a/test/test-constants.go
+++ b/test/test-constants.go
@@ -32,7 +32,7 @@ const (
 	OpId1           = "operation-id-1"
 	OpId2           = "operation-id-2"
 	OpStart         = 1
-	SvcType         = "ClusterSetIP"
+	SvcType         = "ClusterIP"
 )
 
 func GetTestHttpNamespace() *model.Namespace {


### PR DESCRIPTION
_Related to [Issue #22](https://github.com/aws/aws-cloud-map-mcs-controller-for-k8s/issues/22): Support for headless services_

*Description of changes:*
- Added new field `ServiceType` in Endpoint model to represent services of type `Headless` or `ClusterIP`
- Added logic to check and add `ServiceType` in service export controller

_Testing:_

- Added unit testing for new `ServiceType`field
- Modified export scenario to reflect new field; local Kind integration test passing 
- Confirmed that controller is able to correctly identify `ServiceType` in Cloud Map when exporting Headless or ClusterIP services 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
