### PR TITLE
Unit test for ExtractServiceType function

### DIFF
--- a/pkg/controllers/multicluster/utils_test.go
+++ b/pkg/controllers/multicluster/utils_test.go
@@ -489,3 +489,61 @@ func TestCreateServiceImportStruct(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractServiceType(t *testing.T) {
+	tests := []struct {
+		name string
+		svc  *v1.Service
+		want model.ServiceType
+	}{
+		{
+			name: "cluster ip type",
+			svc: &v1.Service{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      test.SvcName,
+					Namespace: test.HttpNsName,
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{{
+						Name:       test.PortName1,
+						Protocol:   test.Protocol1,
+						Port:       test.ServicePort1,
+						TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: test.Port1},
+					}},
+					ClusterIP: "10.108.89.43",
+				},
+				Status: v1.ServiceStatus{},
+			},
+			want: model.ClusterSetIPType,
+		},
+		{
+			name: "headless type",
+			svc: &v1.Service{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      test.SvcName,
+					Namespace: test.HttpNsName,
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{{
+						Name:       test.PortName1,
+						Protocol:   test.Protocol1,
+						Port:       test.ServicePort1,
+						TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: test.Port1},
+					}},
+					ClusterIP: "None",
+				},
+				Status: v1.ServiceStatus{},
+			},
+			want: model.HeadlessType,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtractServiceType(tt.svc); got != tt.want {
+				t.Errorf("ExtractServiceType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
*Description of changes:*
Unit test for `ExtractServiceType` function to that verifies function is able to return properly `ServiceType` from `ClusterIP` field in K8 service spec.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
