### PR TITLE
Importing Headless Services Support for A/AAAA records

### DIFF
--- a/pkg/controllers/multicluster/cloudmap_controller.go
+++ b/pkg/controllers/multicluster/cloudmap_controller.go
@@ -138,7 +138,7 @@ func (r *CloudMapReconciler) reconcileService(ctx context.Context, svc *model.Se
 		}
 
 		// create ServiceImport if it doesn't exist
-		if svcImport, err = r.createAndGetServiceImport(ctx, svc.Namespace, svc.Name, importedSvcPorts, svc.Endpoints); err != nil {
+		if svcImport, err = r.createAndGetServiceImport(ctx, svc, importedSvcPorts); err != nil {
 			return err
 		}
 	}
@@ -174,14 +174,14 @@ func (r *CloudMapReconciler) getServiceImport(ctx context.Context, namespace str
 	return existingServiceImport, err
 }
 
-func (r *CloudMapReconciler) createAndGetServiceImport(ctx context.Context, namespace string, name string, servicePorts []*model.Port, endpoints []*model.Endpoint) (*multiclusterv1alpha1.ServiceImport, error) {
-	toCreate := CreateServiceImportStruct(namespace, name, servicePorts, endpoints)
+func (r *CloudMapReconciler) createAndGetServiceImport(ctx context.Context, svc *model.Service, servicePorts []*model.Port) (*multiclusterv1alpha1.ServiceImport, error) {
+	toCreate := CreateServiceImportStruct(svc, servicePorts)
 	if err := r.Client.Create(ctx, toCreate); err != nil {
 		return nil, err
 	}
-	r.Log.Info("created ServiceImport", "namespace", namespace, "name", name)
+	r.Log.Info("created ServiceImport", "namespace", svc.Namespace, "name", svc.Name)
 
-	return r.getServiceImport(ctx, namespace, name)
+	return r.getServiceImport(ctx, svc.Namespace, svc.Name)
 }
 
 func (r *CloudMapReconciler) getDerivedService(ctx context.Context, namespace string, name string) (*v1.Service, error) {

--- a/pkg/controllers/multicluster/cloudmap_controller.go
+++ b/pkg/controllers/multicluster/cloudmap_controller.go
@@ -138,7 +138,7 @@ func (r *CloudMapReconciler) reconcileService(ctx context.Context, svc *model.Se
 		}
 
 		// create ServiceImport if it doesn't exist
-		if svcImport, err = r.createAndGetServiceImport(ctx, svc.Namespace, svc.Name, importedSvcPorts); err != nil {
+		if svcImport, err = r.createAndGetServiceImport(ctx, svc.Namespace, svc.Name, importedSvcPorts, svc.Endpoints); err != nil {
 			return err
 		}
 	}
@@ -174,8 +174,8 @@ func (r *CloudMapReconciler) getServiceImport(ctx context.Context, namespace str
 	return existingServiceImport, err
 }
 
-func (r *CloudMapReconciler) createAndGetServiceImport(ctx context.Context, namespace string, name string, servicePorts []*model.Port) (*multiclusterv1alpha1.ServiceImport, error) {
-	toCreate := CreateServiceImportStruct(namespace, name, servicePorts)
+func (r *CloudMapReconciler) createAndGetServiceImport(ctx context.Context, namespace string, name string, servicePorts []*model.Port, endpoints []*model.Endpoint) (*multiclusterv1alpha1.ServiceImport, error) {
+	toCreate := CreateServiceImportStruct(namespace, name, servicePorts, endpoints)
 	if err := r.Client.Create(ctx, toCreate); err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/multicluster/utils.go
+++ b/pkg/controllers/multicluster/utils.go
@@ -26,8 +26,6 @@ const (
 
 	// ValueEndpointSliceManagedBy indicates the name of the entity that manages the EndpointSlice.
 	ValueEndpointSliceManagedBy = "aws-cloud-map-mcs-controller-for-k8s"
-
-	LabelEndpointSliceSourceCluster = "multicluster.kubernetes.io/source-cluster"
 )
 
 // ServicePortToPort converts a k8s service port to internal model port
@@ -232,8 +230,7 @@ func CreateEndpointSliceStruct(svc *v1.Service, svcImportName string) *discovery
 				// original ServiceImport name
 				LabelServiceImportName: svcImportName,
 				// 'managed-by' label set to controller
-				LabelEndpointSliceManagedBy:     ValueEndpointSliceManagedBy,
-				LabelEndpointSliceSourceCluster: "test-name",
+				LabelEndpointSliceManagedBy: ValueEndpointSliceManagedBy,
 			},
 			GenerateName: svc.Name + "-",
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(svc, schema.GroupVersionKind{

--- a/pkg/controllers/multicluster/utils.go
+++ b/pkg/controllers/multicluster/utils.go
@@ -142,7 +142,7 @@ func DerivedName(namespace string, name string) string {
 }
 
 // CreateServiceImportStruct creates struct representation of a ServiceImport
-func CreateServiceImportStruct(namespace string, name string, servicePorts []*model.Port, endpoints []*model.Endpoint) *multiclusterv1alpha1.ServiceImport {
+func CreateServiceImportStruct(svc *model.Service, servicePorts []*model.Port) *multiclusterv1alpha1.ServiceImport {
 	serviceImportPorts := make([]multiclusterv1alpha1.ServicePort, 0)
 	for _, port := range servicePorts {
 		serviceImportPorts = append(serviceImportPorts, PortToServiceImportPort(*port))
@@ -150,13 +150,13 @@ func CreateServiceImportStruct(namespace string, name string, servicePorts []*mo
 
 	return &multiclusterv1alpha1.ServiceImport{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:   namespace,
-			Name:        name,
-			Annotations: map[string]string{DerivedServiceAnnotation: DerivedName(namespace, name)},
+			Namespace:   svc.Namespace,
+			Name:        svc.Name,
+			Annotations: map[string]string{DerivedServiceAnnotation: DerivedName(svc.Namespace, svc.Name)},
 		},
 		Spec: multiclusterv1alpha1.ServiceImportSpec{
 			IPs:   []string{},
-			Type:  ServiceTypetoServiceImportType(endpoints[0].ServiceType), // assume each endpoint has the same serviceType
+			Type:  ServiceTypetoServiceImportType(svc.Endpoints[0].ServiceType), // assume each endpoint has the same serviceType
 			Ports: serviceImportPorts,
 		},
 	}
@@ -174,23 +174,7 @@ func CreateDerivedServiceStruct(svcImport *multiclusterv1alpha1.ServiceImport, i
 		svcPorts = append(svcPorts, PortToServicePort(*svcPort))
 	}
 
-	// if svcImport is Headless type, specify ClusterIP field to "None"
-	if svcImport.Spec.Type == multiclusterv1alpha1.Headless {
-		return &v1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace:       svcImport.Namespace,
-				Name:            svcImport.Annotations[DerivedServiceAnnotation],
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
-			},
-			Spec: v1.ServiceSpec{
-				Type:      v1.ServiceTypeClusterIP,
-				Ports:     svcPorts,
-				ClusterIP: "None",
-			},
-		}
-	}
-
-	return &v1.Service{
+	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       svcImport.Namespace,
 			Name:            svcImport.Annotations[DerivedServiceAnnotation],
@@ -201,6 +185,13 @@ func CreateDerivedServiceStruct(svcImport *multiclusterv1alpha1.ServiceImport, i
 			Ports: svcPorts,
 		},
 	}
+
+	// if svcImport is Headless type, specify ClusterIP field to "None"
+	if svcImport.Spec.Type == multiclusterv1alpha1.Headless {
+		svc.Spec.ClusterIP = "None"
+	}
+
+	return svc
 }
 
 func CreateEndpointForSlice(svc *v1.Service, ip string) discovery.Endpoint {
@@ -254,7 +245,7 @@ func ExtractServiceType(svc *v1.Service) model.ServiceType {
 
 // ServiceTypetoServiceImportType converts model service type to multicluster ServiceImport type
 func ServiceTypetoServiceImportType(serviceType model.ServiceType) multiclusterv1alpha1.ServiceImportType {
-	if serviceType.String() == model.HeadlessType.String() {
+	if serviceType == model.HeadlessType {
 		return multiclusterv1alpha1.Headless
 	}
 

--- a/pkg/controllers/multicluster/utils_test.go
+++ b/pkg/controllers/multicluster/utils_test.go
@@ -450,6 +450,7 @@ func TestPortsEqualIgnoreOrder(t *testing.T) {
 func TestCreateServiceImportStruct(t *testing.T) {
 	type args struct {
 		servicePorts []*model.Port
+		endpoints    []*model.Endpoint
 	}
 	tests := []struct {
 		name string
@@ -462,6 +463,11 @@ func TestCreateServiceImportStruct(t *testing.T) {
 				servicePorts: []*model.Port{
 					{Name: test.PortName1, Protocol: test.Protocol1, Port: test.Port1},
 					{Name: test.PortName2, Protocol: test.Protocol1, Port: test.Port2},
+				},
+				endpoints: []*model.Endpoint{
+					{
+						ServiceType: model.ClusterSetIPType,
+					},
 				},
 			},
 			want: multiclusterv1alpha1.ServiceImport{
@@ -483,7 +489,7 @@ func TestCreateServiceImportStruct(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := CreateServiceImportStruct(test.HttpNsName, test.SvcName, tt.args.servicePorts); !reflect.DeepEqual(*got, tt.want) {
+			if got := CreateServiceImportStruct(test.HttpNsName, test.SvcName, tt.args.servicePorts, tt.args.endpoints); !reflect.DeepEqual(*got, tt.want) {
 				t.Errorf("CreateServiceImportStruct() = %v, want %v", got, tt.want)
 			}
 		})
@@ -542,6 +548,32 @@ func TestExtractServiceType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := ExtractServiceType(tt.svc); got != tt.want {
+				t.Errorf("ExtractServiceType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestServiceTypetoServiceImportType(t *testing.T) {
+	tests := []struct {
+		name    string
+		svcType model.ServiceType
+		want    multiclusterv1alpha1.ServiceImportType
+	}{
+		{
+			name:    "cluster ip type",
+			svcType: model.ClusterSetIPType,
+			want:    multiclusterv1alpha1.ClusterSetIP,
+		},
+		{
+			name:    "headless type",
+			svcType: model.HeadlessType,
+			want:    multiclusterv1alpha1.Headless,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ServiceTypetoServiceImportType(tt.svcType); got != tt.want {
 				t.Errorf("ExtractServiceType() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
_Related to [Issue #22](https://github.com/aws/aws-cloud-map-mcs-controller-for-k8s/issues/22): Support for headless services_

*Description of changes:*

- Added logic in `ServiceImportController` for detecting `ServiceType` of importing Service and typing `ServiceImport` object accordingly (either Headless or ClusterSetIP)
- Added unit tests for new functions related to new logic

Note: This change currently only discovers `A/AAAA` records; support for `SRV` records will be added after cluster annotations are added to `EndpointSlices` with Source-Cluster label PR (#179). Additionally, the logic currently assumes that all Endpoints have the same `ServiceType`, and therefore fetches the `ServiceType` from the first endpoint in the Service. This may be changed in the conflict resolution story.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
