### PR TITLE
Update the ClusterProperty id.k8s.io

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,13 +101,13 @@ make install
 # customresourcedefinition.apiextensions.k8s.io/serviceimports.multicluster.x-k8s.io created
 ```
 
-Register a unique `id.k8s.io` and `clusterset.k8s.io` in your cluster:
+Register a unique `cluster.clusterset.k8s.io` and `clusterset.k8s.io` in your cluster:
 ```bash
 kubectl apply -f samples/example-clusterproperty.yaml
-# clusterproperty.about.k8s.io/id.k8s.io created
+# clusterproperty.about.k8s.io/cluster.clusterset.k8s.io created
 # clusterproperty.about.k8s.io/clusterset.k8s.io created
 ```
-> ⚠ **Note:** If you are creating multiple clusters, ensure you create unique `id.k8s.io` identifiers for each cluster.
+> ⚠ **Note:** If you are creating multiple clusters, ensure you create unique `cluster.clusterset.k8s.io` identifiers for each cluster.
 
 
 To run the controller, run the following command. The controller runs in an infinite loop so open another terminal to create CRDs. (Ctrl+C to exit)

--- a/README.md
+++ b/README.md
@@ -13,11 +13,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/aws/aws-cloud-map-mcs-controller-for-k8s)](https://goreportcard.com/report/github.com/aws/aws-cloud-map-mcs-controller-for-k8s)
 
 ## Introduction
-The AWS Cloud Map Multi-cluster Service Discovery Controller for Kubernetes (K8s) implements the Kubernetes [multi-cluster services API](https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api) specification, which allows services to communicate across multiple clusters. The implementation relies on [AWS Cloud Map](https://aws.amazon.com/cloud-map/) for enabling cross-cluster service discovery.
-
-See the demo from AWS Container Day x KubeCon!
-
-[![Watch the video](https://img.youtube.com/vi/3f0Tv7IiQQw/0.jpg)](https://youtu.be/3f0Tv7IiQQw?t=24458)
+The AWS Cloud Map Multi-cluster Service Discovery Controller for Kubernetes (K8s) implements the Kubernetes [KEP-1645: Multi-Cluster Services API](https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api) and [KEP-2149: ClusterId for ClusterSet identification](https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/2149-clusterid), which allows services to communicate across multiple clusters. The implementation relies on [AWS Cloud Map](https://aws.amazon.com/cloud-map/) for enabling cross-cluster service discovery.
 
 ## Installation
 
@@ -37,7 +33,7 @@ Perform the following installation steps on each participating cluster.
 
 #### Configure CoreDNS
 
-Install the The CoreDNS multicluster plugin into each participating cluster. The multicluster plugin enables CoreDNS to lifecycle manage DNS records for `ServiceImport` objects.
+Install the CoreDNS multicluster plugin into each participating cluster. The multicluster plugin enables CoreDNS to lifecycle manage DNS records for `ServiceImport` objects.
 
 To install the plugin, run the following commands.
 
@@ -63,26 +59,26 @@ The controller must have sufficient IAM permissions to perform required Cloud Ma
 
 ## Usage
 
-### Configure `id.k8s.io` and `clusterset.k8s.io`
+### Configure `cluster.clusterset.k8s.io` and `clusterset.k8s.io`
 
-`id.k8s.io` is a unique identifier that uniquely identifies a cluster.
+`cluster.clusterset.k8s.io` is a unique identifier for the cluster.
 
-`clusterset.k8s.io` is a unique identifier that uniquely identifies the set of clusters in your multicluster. This will be the same across all clusters in the set.
+`clusterset.k8s.io` is an identifier that relates to the `ClusterSet` in which the cluster belongs. 
 
 ```yaml
 apiVersion: about.k8s.io/v1alpha1
 kind: ClusterProperty
 metadata:
-  name: id.k8s.io
+  name: cluster.clusterset.k8s.io
 spec:
-  value: [Your cluster identifier]
+  value: [Your Cluster identifier]
 ---
 apiVersion: about.k8s.io/v1alpha1
 kind: ClusterProperty
 metadata:
   name: clusterset.k8s.io
 spec:
-  value: [Your cluster set identifier]
+  value: [Your ClusterSet identifier]
 ```
 
 **Example:**
@@ -90,7 +86,7 @@ spec:
 apiVersion: about.k8s.io/v1alpha1
 kind: ClusterProperty
 metadata:
-  name: id.k8s.io
+  name: cluster.clusterset.k8s.io
 spec:
   value: my-first-cluster
 ---

--- a/config/samples/about_v1alpha1_clusterproperty_clusterId.yaml
+++ b/config/samples/about_v1alpha1_clusterproperty_clusterId.yaml
@@ -1,8 +1,0 @@
-# An example object of `id.k8s.io ClusterProperty` 
-
-apiVersion: about.k8s.io/v1alpha1
-kind: ClusterProperty
-metadata:
-  name: id.k8s.io
-spec:
-  value: sample-mcs-clusterid

--- a/config/samples/about_v1alpha1_clusterproperty_clustersetId.yaml
+++ b/config/samples/about_v1alpha1_clusterproperty_clustersetId.yaml
@@ -1,8 +1,0 @@
-# An example object of `clusterset.k8s.io ClusterProperty`:
-
-apiVersion: about.k8s.io/v1alpha1
-kind: ClusterProperty
-metadata:
-  name: clusterset.k8s.io
-spec:
-  value: sample-mcs-clustersetid

--- a/config/samples/multicluster_v1alpha1_serviceexport.yaml
+++ b/config/samples/multicluster_v1alpha1_serviceexport.yaml
@@ -1,7 +1,0 @@
-apiVersion: multicluster.x-k8s.io/v1alpha1
-kind: ServiceExport
-metadata:
-  name: serviceexport-sample
-spec:
-  # Add fields here
-  foo: bar

--- a/config/samples/multicluster_v1alpha1_serviceimport.yaml
+++ b/config/samples/multicluster_v1alpha1_serviceimport.yaml
@@ -1,7 +1,0 @@
-apiVersion: multicluster.x-k8s.io/v1alpha1
-kind: ServiceImport
-metadata:
-  name: serviceimport-sample
-spec:
-  # Add fields here
-  foo: bar

--- a/integration/eks-test/configs/e2e-clusterproperty-1.yaml
+++ b/integration/eks-test/configs/e2e-clusterproperty-1.yaml
@@ -1,7 +1,7 @@
 apiVersion: about.k8s.io/v1alpha1
 kind: ClusterProperty
 metadata:
-  name: id.k8s.io
+  name: cluster.clusterset.k8s.io
 spec:
   value: eks-e2e-clusterid-1
 ---

--- a/integration/eks-test/configs/e2e-clusterproperty-2.yaml
+++ b/integration/eks-test/configs/e2e-clusterproperty-2.yaml
@@ -1,7 +1,7 @@
 apiVersion: about.k8s.io/v1alpha1
 kind: ClusterProperty
 metadata:
-  name: id.k8s.io
+  name: cluster.clusterset.k8s.io
 spec:
   value: eks-e2e-clusterid-2
 ---

--- a/integration/kind-test/configs/dnsutils-pod.yaml
+++ b/integration/kind-test/configs/dnsutils-pod.yaml
@@ -8,7 +8,7 @@ spec:
     - command:
         - sleep
         - "3600"
-      image: registry.k8s.io/e2e-test-images/jessie-dnsutils:1.3
+      image: gcr.io/kubernetes-e2e-test-images/dnsutils:1.3
       name: dnsutils
       imagePullPolicy: IfNotPresent
   restartPolicy: Always

--- a/integration/kind-test/configs/e2e-clusterproperty.yaml
+++ b/integration/kind-test/configs/e2e-clusterproperty.yaml
@@ -1,7 +1,7 @@
 apiVersion: about.k8s.io/v1alpha1
 kind: ClusterProperty
 metadata:
-  name: id.k8s.io
+  name: cluster.clusterset.k8s.io
 spec:
   value: kind-e2e-clusterid-1
 ---

--- a/integration/kind-test/scripts/common.sh
+++ b/integration/kind-test/scripts/common.sh
@@ -15,7 +15,6 @@ export KIND_SHORT='cloud-map-e2e'
 export CLUSTER='kind-cloud-map-e2e'
 export CLUSTERID1='kind-e2e-clusterid-1'
 export CLUSTERSETID1='kind-e2e-clustersetid-1'
-export DNS_POD='dnsutils'
 export IMAGE='kindest/node:v1.21.12@sha256:f316b33dd88f8196379f38feb80545ef3ed44d9197dca1bfd48bcb1583210207'
 export EXPECTED_ENDPOINT_COUNT=5
 export UPDATED_ENDPOINT_COUNT=6

--- a/integration/kind-test/scripts/dns-test.sh
+++ b/integration/kind-test/scripts/dns-test.sh
@@ -27,12 +27,12 @@ expected_endpoint_count=$1
 
 # Install dnsutils pod
 $KUBECTL_BIN apply -f "$KIND_CONFIGS/dnsutils-pod.yaml"
-$KUBECTL_BIN wait --for=condition=ready pod/$DNS_POD # wait until pod is deployed
+$KUBECTL_BIN wait --for=condition=ready pod/dnsutils # wait until pod is deployed
 
 # Perform a dig to cluster-local CoreDNS
 # TODO: parse dig outputs for more precise verification - check specifics IPs?
 echo "performing dig for A/AAAA records..."
-addresses=$($KUBECTL_BIN exec $DNS_POD -- dig +all +ans $SERVICE.$NAMESPACE.svc.clusterset.local +short)
+addresses=$($KUBECTL_BIN exec dnsutils -- dig +all +ans $SERVICE.$NAMESPACE.svc.clusterset.local +short)
 exit_code=$?
 echo "$addresses"
 
@@ -45,7 +45,7 @@ fi
 checkDNS "$addresses"
 
 echo "performing dig for SRV records..."
-addresses=$($KUBECTL_BIN exec $DNS_POD -- dig +all +ans $SERVICE.$NAMESPACE.svc.clusterset.local. SRV +short)
+addresses=$($KUBECTL_BIN exec dnsutils -- dig +all +ans $SERVICE.$NAMESPACE.svc.clusterset.local. SRV +short)
 exit_code=$?
 echo "$addresses"
 

--- a/pkg/apis/multicluster/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/multicluster/v1alpha1/zz_generated.deepcopy.go
@@ -23,7 +23,7 @@ package v1alpha1
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/pkg/model/cluster.go
+++ b/pkg/model/cluster.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	ClusterIdName    = "id.k8s.io"
-	ClusterSetIdName = "clusterset.k8s.io"
+	ClusterIdPropertyName    = "cluster.clusterset.k8s.io"
+	ClusterSetIdPropertyName = "clusterset.k8s.io"
 )
 
 // Non-exported type, accessible via read-only func
@@ -73,9 +73,9 @@ func (r *ClusterUtils) LoadClusterProperties(ctx context.Context) error {
 	}
 	for _, clusterProperty := range clusterPropertyList.Items {
 		switch clusterProperty.Name {
-		case ClusterIdName:
+		case ClusterIdPropertyName:
 			r.clusterProperties.clusterId = clusterProperty.Spec.Value
-		case ClusterSetIdName:
+		case ClusterSetIdPropertyName:
 			r.clusterProperties.clusterSetId = clusterProperty.Spec.Value
 		}
 	}

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -82,7 +82,7 @@ func TestClusterUtils_GetClusterProperties(t *testing.T) {
 func ClusterIdForTest(clusterId string) *aboutv1alpha1.ClusterProperty {
 	return &aboutv1alpha1.ClusterProperty{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: ClusterIdName,
+			Name: ClusterIdPropertyName,
 		},
 		Spec: aboutv1alpha1.ClusterPropertySpec{
 			Value: clusterId,
@@ -93,7 +93,7 @@ func ClusterIdForTest(clusterId string) *aboutv1alpha1.ClusterProperty {
 func ClusterSetIdForTest(clusterSetId string) *aboutv1alpha1.ClusterProperty {
 	return &aboutv1alpha1.ClusterProperty{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: ClusterSetIdName,
+			Name: ClusterSetIdPropertyName,
 		},
 		Spec: aboutv1alpha1.ClusterPropertySpec{
 			Value: clusterSetId,

--- a/samples/example-clusterproperty.yaml
+++ b/samples/example-clusterproperty.yaml
@@ -1,9 +1,9 @@
-# An example object of `id.k8s.io ClusterProperty` 
+# An example object of `cluster.clusterset.k8s.io ClusterProperty`
 
 apiVersion: about.k8s.io/v1alpha1
 kind: ClusterProperty
 metadata:
-  name: id.k8s.io
+  name: cluster.clusterset.k8s.io
 spec:
   value: sample-mcs-clusterid
 ---

--- a/test/test-constants.go
+++ b/test/test-constants.go
@@ -171,7 +171,7 @@ func GetTestEndpoints(count int) (endpts []*model.Endpoint) {
 func ClusterIdForTest() *aboutv1alpha1.ClusterProperty {
 	return &aboutv1alpha1.ClusterProperty{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: model.ClusterIdName,
+			Name: model.ClusterIdPropertyName,
 		},
 		Spec: aboutv1alpha1.ClusterPropertySpec{
 			Value: ClusterId1,
@@ -182,7 +182,7 @@ func ClusterIdForTest() *aboutv1alpha1.ClusterProperty {
 func ClusterSetIdForTest() *aboutv1alpha1.ClusterProperty {
 	return &aboutv1alpha1.ClusterProperty{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: model.ClusterSetIdName,
+			Name: model.ClusterSetIdPropertyName,
 		},
 		Spec: aboutv1alpha1.ClusterPropertySpec{
 			Value: ClusterSet,


### PR DESCRIPTION
*Issue #, if available:*  

*Description of changes:* Update the ClusterProperty  from `id.k8s.io` to `cluster.clusterset.k8s.io` as per the guidance of the sig-multicluster group, more context [here](https://docs.google.com/document/d/12znQZGyRdUWbHkKuif0ySZdm0SMIymGJFQvAxVREMpE/edit#bookmark=id.1c19pssr2xaz). Verified the new name with @lauralorenz, and the [KEP-2149: ClusterId for ClusterSet identification](https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/2149-clusterid) is also going to be updated soon.

Other changes:
* Cleaned up README - removed outdated links and texts, updated summary.
* Removed unused samples

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
