### PR TITLE
Remove register/deregister instances operation polling. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 KUBEBUILDER_ASSETS?="$(shell $(ENVTEST) use -i $(ENVTEST_KUBERNETES_VERSION) --bin-dir=$(ENVTEST_ASSETS_DIR) -p path)"
 
 .PHONY: test
-test: manifests generate generate-mocks fmt vet test-setup ## Run tests
+test: manifests generate generate-mocks fmt vet test-setup goimports lint ## Run tests
 	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./... -coverprofile cover.out -covermode=atomic
 
 test-setup: setup-envtest ## Ensure test environment has been downloaded
@@ -117,7 +117,7 @@ eks-test:
 ##@ Build
 
 .DEFAULT: build
-build: test goimports lint ## Build manager binary.
+build: test ## Build manager binary.
 	go build -ldflags="-s -w -X ${PKG}.GitVersion=${GIT_TAG} -X ${PKG}.GitCommit=${GIT_COMMIT}" -o bin/manager main.go
 
 run: test ## Run a controller from your host.

--- a/integration/janitor/janitor.go
+++ b/integration/janitor/janitor.go
@@ -81,7 +81,7 @@ func (j *cloudMapJanitor) deregisterInstances(ctx context.Context, nsName string
 		model.ClusterSetIdAttr: j.clusterSetId,
 	}
 
-	insts, err := j.sdApi.DiscoverInstances(ctx, nsName, svcName, &queryParameters)
+	insts, err := j.sdApi.DiscoverInstances(ctx, nsName, svcName, queryParameters)
 	j.checkOrFail(err,
 		fmt.Sprintf("service has %d instances to clean", len(insts)),
 		"could not list instances to cleanup")

--- a/integration/janitor/janitor_test.go
+++ b/integration/janitor/janitor_test.go
@@ -32,7 +32,7 @@ func TestCleanupHappyCase(t *testing.T) {
 		Return(map[string]*model.Namespace{test.HttpNsName: test.GetTestHttpNamespace()}, nil)
 	tj.mockApi.EXPECT().GetServiceIdMap(context.TODO(), test.HttpNsId).
 		Return(map[string]string{test.SvcName: test.SvcId}, nil)
-	tj.mockApi.EXPECT().DiscoverInstances(context.TODO(), test.HttpNsName, test.SvcName, &map[string]string{
+	tj.mockApi.EXPECT().DiscoverInstances(context.TODO(), test.HttpNsName, test.SvcName, map[string]string{
 		model.ClusterSetIdAttr: test.ClusterSet,
 	}).
 		Return([]types.HttpInstanceSummary{{InstanceId: aws.String(test.EndptId1)}}, nil)

--- a/pkg/apis/multicluster/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/multicluster/v1alpha1/zz_generated.deepcopy.go
@@ -23,7 +23,7 @@ package v1alpha1
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/pkg/cloudmap/api.go
+++ b/pkg/cloudmap/api.go
@@ -27,7 +27,7 @@ type ServiceDiscoveryApi interface {
 	GetServiceIdMap(ctx context.Context, namespaceId string) (serviceIdMap map[string]string, err error)
 
 	// DiscoverInstances returns a list of service instances registered to a given service.
-	DiscoverInstances(ctx context.Context, nsName string, svcName string, queryParameters *map[string]string) (insts []types.HttpInstanceSummary, err error)
+	DiscoverInstances(ctx context.Context, nsName string, svcName string, queryParameters map[string]string) (insts []types.HttpInstanceSummary, err error)
 
 	// ListOperations returns a map of operations to their status matching a list of filters.
 	ListOperations(ctx context.Context, opFilters []types.OperationFilter) (operationStatusMap map[string]types.OperationStatus, err error)
@@ -59,7 +59,7 @@ type serviceDiscoveryApi struct {
 // NewServiceDiscoveryApiFromConfig creates a new AWS Cloud Map API connection manager from an AWS client config.
 func NewServiceDiscoveryApiFromConfig(cfg *aws.Config) ServiceDiscoveryApi {
 	return &serviceDiscoveryApi{
-		log:       common.NewLogger("cloudmap"),
+		log:       common.NewLogger("cloudmap", "api"),
 		awsFacade: NewAwsFacadeFromConfig(cfg),
 	}
 }
@@ -113,7 +113,7 @@ func (sdApi *serviceDiscoveryApi) GetServiceIdMap(ctx context.Context, nsId stri
 	return serviceIdMap, nil
 }
 
-func (sdApi *serviceDiscoveryApi) DiscoverInstances(ctx context.Context, nsName string, svcName string, queryParameters *map[string]string) (insts []types.HttpInstanceSummary, err error) {
+func (sdApi *serviceDiscoveryApi) DiscoverInstances(ctx context.Context, nsName string, svcName string, queryParameters map[string]string) (insts []types.HttpInstanceSummary, err error) {
 	input := &sd.DiscoverInstancesInput{
 		NamespaceName: aws.String(nsName),
 		ServiceName:   aws.String(svcName),
@@ -121,7 +121,7 @@ func (sdApi *serviceDiscoveryApi) DiscoverInstances(ctx context.Context, nsName 
 		MaxResults:    aws.Int32(1000),
 	}
 	if queryParameters != nil {
-		input.QueryParameters = *queryParameters
+		input.QueryParameters = queryParameters
 	}
 	out, err := sdApi.awsFacade.DiscoverInstances(ctx, input)
 

--- a/pkg/cloudmap/api_test.go
+++ b/pkg/cloudmap/api_test.go
@@ -121,7 +121,7 @@ func TestServiceDiscoveryApi_DiscoverInstances_HappyCase(t *testing.T) {
 			},
 		}, nil)
 
-	insts, err := sdApi.DiscoverInstances(context.TODO(), test.HttpNsName, test.SvcName, &map[string]string{model.ClusterSetIdAttr: test.ClusterSet})
+	insts, err := sdApi.DiscoverInstances(context.TODO(), test.HttpNsName, test.SvcName, map[string]string{model.ClusterSetIdAttr: test.ClusterSet})
 	assert.Nil(t, err, "No error for happy case")
 	assert.True(t, len(insts) == 2)
 	assert.Equal(t, test.EndptId1, *insts[0].InstanceId)

--- a/pkg/cloudmap/client_test.go
+++ b/pkg/cloudmap/client_test.go
@@ -48,7 +48,7 @@ func TestServiceDiscoveryClient_ListServices_HappyCase(t *testing.T) {
 	tc.mockCache.EXPECT().CacheServiceIdMap(test.HttpNsName, getServiceIdMapForTest())
 
 	tc.mockCache.EXPECT().GetEndpoints(test.HttpNsName, test.SvcName).Return(nil, false)
-	tc.mockApi.EXPECT().DiscoverInstances(context.TODO(), test.HttpNsName, test.SvcName, &map[string]string{
+	tc.mockApi.EXPECT().DiscoverInstances(context.TODO(), test.HttpNsName, test.SvcName, map[string]string{
 		model.ClusterSetIdAttr: test.ClusterSet,
 	}).Return(getHttpInstanceSummaryForTest(), nil)
 
@@ -117,7 +117,7 @@ func TestServiceDiscoveryClient_ListServices_InstanceError(t *testing.T) {
 
 	endptErr := errors.New("error listing endpoints")
 	tc.mockCache.EXPECT().GetEndpoints(test.HttpNsName, test.SvcName).Return(nil, false)
-	tc.mockApi.EXPECT().DiscoverInstances(context.TODO(), test.HttpNsName, test.SvcName, &map[string]string{
+	tc.mockApi.EXPECT().DiscoverInstances(context.TODO(), test.HttpNsName, test.SvcName, map[string]string{
 		model.ClusterSetIdAttr: test.ClusterSet,
 	}).
 		Return([]types.HttpInstanceSummary{}, endptErr)
@@ -264,7 +264,7 @@ func TestServiceDiscoveryClient_GetService_HappyCase(t *testing.T) {
 	tc.mockCache.EXPECT().CacheServiceIdMap(test.HttpNsName, getServiceIdMapForTest())
 
 	tc.mockCache.EXPECT().GetEndpoints(test.HttpNsName, test.SvcName).Return([]*model.Endpoint{}, false)
-	tc.mockApi.EXPECT().DiscoverInstances(context.TODO(), test.HttpNsName, test.SvcName, &map[string]string{
+	tc.mockApi.EXPECT().DiscoverInstances(context.TODO(), test.HttpNsName, test.SvcName, map[string]string{
 		model.ClusterSetIdAttr: test.ClusterSet,
 	}).
 		Return(getHttpInstanceSummaryForTest(), nil)
@@ -335,10 +335,6 @@ func TestServiceDiscoveryClient_RegisterEndpoints(t *testing.T) {
 		Return(test.OpId1, nil)
 	tc.mockApi.EXPECT().RegisterInstance(context.TODO(), test.SvcId, test.EndptId2, attrs2).
 		Return(test.OpId2, nil)
-	tc.mockApi.EXPECT().ListOperations(context.TODO(), gomock.Any()).
-		Return(map[string]types.OperationStatus{
-			test.OpId1: types.OperationStatusSuccess,
-			test.OpId2: types.OperationStatusSuccess}, nil)
 
 	tc.mockCache.EXPECT().EvictEndpoints(test.HttpNsName, test.SvcName)
 
@@ -356,10 +352,6 @@ func TestServiceDiscoveryClient_DeleteEndpoints(t *testing.T) {
 
 	tc.mockApi.EXPECT().DeregisterInstance(context.TODO(), test.SvcId, test.EndptId1).Return(test.OpId1, nil)
 	tc.mockApi.EXPECT().DeregisterInstance(context.TODO(), test.SvcId, test.EndptId2).Return(test.OpId2, nil)
-	tc.mockApi.EXPECT().ListOperations(context.TODO(), gomock.Any()).
-		Return(map[string]types.OperationStatus{
-			test.OpId1: types.OperationStatusSuccess,
-			test.OpId2: types.OperationStatusSuccess}, nil)
 
 	tc.mockCache.EXPECT().EvictEndpoints(test.HttpNsName, test.SvcName)
 

--- a/pkg/controllers/multicluster/serviceexport_controller.go
+++ b/pkg/controllers/multicluster/serviceexport_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	aboutv1alpha1 "github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/apis/about/v1alpha1"
 	"github.com/aws/aws-cloud-map-mcs-controller-for-k8s/pkg/cloudmap"
@@ -14,7 +15,9 @@ import (
 	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -295,6 +298,11 @@ func (r *ServiceExportReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&source.Kind{Type: &aboutv1alpha1.ClusterProperty{}},
 			handler.EnqueueRequestsFromMapFunc(r.clusterPropertyMappingFunction()),
 		).
+		WithOptions(controller.Options{
+			// rate-limiting is applied to reconcile responses with an error
+			// We are increasing the base delay to 500ms, defaults baseDelay: 5ms, maxDelay: 1000s
+			RateLimiter: workqueue.NewItemExponentialFailureRateLimiter(500*time.Millisecond, 1000*time.Second),
+		}).
 		Complete(r)
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* ListOperation api is a bottleneck, and thus we are removing the operation polling. By removing it we are making the instances updates to CloudMap async. 
* Increasing the base delay of the reconciler's rate limiter.
* Minor improvements  - Improve logger's tags, remove unnecessary ref to map as DiscoverInstance params, make goimports and lint part of the test target

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
