### PR TITLE
Update golangci-lint version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ golangci-lint: ## Download golangci-lint
 ifneq ($(shell test -f $(GOLANGCI_LINT); echo $$?), 0)
 	@echo Getting golangci-lint...
 	@mkdir -p $(shell pwd)/bin
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell pwd)/bin v1.46.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell pwd)/bin v1.50.1
 endif
 
 GOIMPORTS = $(shell pwd)/bin/goimports


### PR DESCRIPTION
*Issue #, if available:* Not related to an issue

*Description of changes:* When running `make run`, the linter was failing to be downloaded due to versioning issue with Apple Intel based computers.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
