### PR TITLE
Add sync code when reconcille endpoint

### DIFF
--- a/pkg/controllers/multicluster/cloudmap_controller.go
+++ b/pkg/controllers/multicluster/cloudmap_controller.go
@@ -125,7 +125,7 @@ func (r *CloudMapReconciler) reconcileNamespace(ctx context.Context, namespaceNa
 }
 
 func (r *CloudMapReconciler) reconcileService(ctx context.Context, svc *model.Service) error {
-	r.Log.Debug("syncing service", "namespace", svc.Namespace, "service", svc.Name)
+	r.Log.Info("syncing service", "namespace", svc.Namespace, "service", svc.Name)
 
 	importedSvcPorts := ExtractServicePorts(svc.Endpoints)
 
@@ -158,6 +158,7 @@ func (r *CloudMapReconciler) reconcileService(ctx context.Context, svc *model.Se
 		clusterImportedSvcPorts := ExtractServicePorts(endpoints)
 
 		derivedService, err := r.getDerivedService(ctx, svc.Namespace, svc.Name, clusterId)
+
 		if err != nil {
 			if !errors.IsNotFound(err) {
 				return err
@@ -256,6 +257,9 @@ func (r *CloudMapReconciler) updateEndpointSlices(ctx context.Context, svcImport
 	}
 
 	changes := plan.CalculateChanges()
+	// // log changes and endpoints
+	// r.Log.Info("changes", "create", len(changes.Create), "update", len(changes.Update), "delete", len(changes.Delete))
+	// r.Log.Info("desiredEndpoints", "endpoints", desiredEndpoints)
 
 	for _, sliceToUpdate := range changes.Update {
 		r.Log.Debug("updating EndpointSlice", "namespace", sliceToUpdate.Namespace, "name", sliceToUpdate.Name)


### PR DESCRIPTION
### re-produce

1. condition.ready 를 `false` 로 강제로 세팅한다
2. desired endpoint conditions.ready 가 true 임에도 불구하고 sync 하지 않는다

(실제 deploy 과정에서 생기는 케이스)

1. zmq 등을 rolling update 하는 순간, new endpoint 가 바로 health check 가 되지 않을 경우
2. mcs controller fetch 가 돌면서, cloudmap 에 `ready:false` 인 상태로 publish
3. edge cluster 가 그때 fetch 하면, `ready:false` 인 채로 가져옴
4. 이후에는 실제로 ready가 true 로 바뀌더라도 ready는 sync 되지 않음

## Solution
flag 를 하나 만들어서 ready (existing <-> desired) 이 다를 때, true 로 하여 업데이트를 트리거한다


